### PR TITLE
Add useragent information to Rlabkey connections

### DIFF
--- a/Rlabkey/R/labkey.setCurlOptions.R
+++ b/Rlabkey/R/labkey.setCurlOptions.R
@@ -20,7 +20,7 @@ PACKAGE_ENV = new.env()
 labkey.setCurlOptions <- function(...)
 {
     # default curl options
-    options <- curlOptions(ssl.verifyhost=2, ssl.verifypeer=TRUE, followlocation=TRUE, sslversion=1L)
+    options <- curlOptions(ssl.verifyhost=2, ssl.verifypeer=TRUE, followlocation=TRUE, sslversion=1L, useragent = "Rlabkey")
 
     # check if a certificate bundle has been specified from the environment variable
     vars <- Sys.getenv("RLABKEY_CAINFO_FILE")


### PR DESCRIPTION
Setting the useragent by default would help tracking Rlabkey usage in the tomcat logs. It is currently empty.