### PR TITLE
Honor saveBatch's baseUrl parameter

### DIFF
--- a/Rlabkey/R/labkey.saveBatch.R
+++ b/Rlabkey/R/labkey.saveBatch.R
@@ -16,7 +16,7 @@
 
 labkey.saveBatch <- function(baseUrl=NULL, folderPath, assayName, resultDataFrame, batchPropertyList=NULL, runPropertyList=NULL)
 {
-baseUrl = labkey.getBaseUrl()
+baseUrl = labkey.getBaseUrl(baseUrl)
 
 ## Error if any of baseUrl, folderPathare missing
 if(exists("baseUrl")==FALSE || is.null(baseUrl) || exists("folderPath")==FALSE || exists("assayName")==FALSE  || exists("resultDataFrame")==FALSE)


### PR DESCRIPTION
saveBatch takes an optional baseUrl parameter, but the value passed in is immediately overwritten. The change matches how baseUrl is handled in the other Rlabkey functions.