### PR TITLE
Fix for makeFilter for encoding reserved characters.

### DIFF
--- a/Rlabkey/R/makeFilter.R
+++ b/Rlabkey/R/makeFilter.R
@@ -114,7 +114,7 @@
  				if(is.null(fop)==TRUE) stop ("Invalid operator name.")
  				# url encode column name and value
  				colnam <- URLencode(fmat[i,1])
- 				fvalue <- URLencode(fmat[i,3])
+ 				fvalue <- URLencode(fmat[i,3], reserved = TRUE)
  				filters[i] <- paste(colnam,"~",fop,"=",fvalue,sep="")
  			}
 


### PR DESCRIPTION
Queries that include `+` in their values are not returning results for those values. Setting `reserved=TRUE` in `URLencode` fixes this issue. See the `URLencode` help file for more about this parameter. 