### PR TITLE
Issue 38368: _ now used instead of --

### DIFF
--- a/Rlabkey/R/makeDF.R
+++ b/Rlabkey/R/makeDF.R
@@ -193,7 +193,7 @@ return(filtered)
 
 .getRNameFromName <- function(lkname, existing=NULL)
 {
-	rname <- gsub("::", "--", lkname)
+	rname <- gsub("::", "_", lkname)
 	rname <- tolower(chartr(" /", "__", rname))
 
 	if (length(existing)>0)


### PR DESCRIPTION
Calling data.frame$myPivotColumn was returning an error due to the -- (most likely because it was interpreting the - as a subtraction operator). Changed it to _ and now data.frame$myPivotColumn doesn't throw an error