### PR TITLE
Rlabkey version 2.5.0 provenance doc fixes related to CRAN check WARNINGS/NOTES

### DIFF
--- a/Rlabkey/man/labkey.insertRows.Rd
+++ b/Rlabkey/man/labkey.insertRows.Rd
@@ -95,29 +95,40 @@ result <- labkey.deleteRows(baseUrl="http://localhost:8080/labkey",
     toDelete=deleterow)
 
 ## Example of creating a provenance run with an initial step with material inputs, a second step
-## with provenance mapping to link existing samples with newly inserted samples and a final step with
-## a data output
+## with provenance mapping to link existing samples with newly inserted samples, and a final step
+## with a data output
 ##
-mi <- data.frame(lsid=c("urn:lsid:labkey.com:Sample.251.MySamples:sample1", "urn:lsid:labkey.com:Sample.251.MySamples:sample2"))
-p <- labkey.provenance.createProvenanceParams(name="step1", description="initial step", materialInputs=mi)
-ra <- labkey.provenance.startRecording(baseUrl="https://labkey.org/labkey/", folderPath = "Provenance", provenanceParams=p)
+mi <- data.frame(lsid=c("urn:lsid:labkey.com:Sample.251.MySamples:sample1",
+        "urn:lsid:labkey.com:Sample.251.MySamples:sample2"))
+p <- labkey.provenance.createProvenanceParams(name="step1", description="initial step",
+        materialInputs=mi)
+ra <- labkey.provenance.startRecording(baseUrl="https://labkey.org/labkey/",
+        folderPath = "Provenance", provenanceParams=p)
 
 rows <- fromJSON(txt='[{
         "name" : "sample3",
         "protein" : "p3",
-        "prov:objectInputs" : ["urn:lsid:labkey.com:Sample.251.MySamples:sample21", "urn:lsid:labkey.com:Sample.251.MySamples:sample22"]
+        "prov:objectInputs" : [
+            "urn:lsid:labkey.com:Sample.251.MySamples:sample21",
+            "urn:lsid:labkey.com:Sample.251.MySamples:sample22"
+        ]
     },{
         "name" : "sample4",
         "protein" : "p4",
-        "prov:objectInputs" : ["urn:lsid:labkey.com:Sample.251.MySamples:sample21", "urn:lsid:labkey.com:Sample.251.MySamples:sample22"]
+        "prov:objectInputs" : [
+            "urn:lsid:labkey.com:Sample.251.MySamples:sample21",
+            "urn:lsid:labkey.com:Sample.251.MySamples:sample22"
+        ]
     }
 ]')
 
 labkey.insertRows(baseUrl="https://labkey.org/labkey/", folderPath = "Provenance",
     schemaName="samples", queryName="MySamples", toInsert=rows,
-    provenanceParams=labkey.provenance.createProvenanceParams(name="query step", recordingId=ra$recordingId))
+    provenanceParams=labkey.provenance.createProvenanceParams(name="query step",
+        recordingId=ra$recordingId))
 labkey.provenance.stopRecording(baseUrl="https://labkey.org/labkey/", folderPath = "Provenance",
-    provenanceParams=labkey.provenance.createProvenanceParams(name="final step", recordingId=ra$recordingId, dataOutputs=do))
+    provenanceParams=labkey.provenance.createProvenanceParams(name="final step",
+    recordingId=ra$recordingId, dataOutputs=do))
 }
 }
 \keyword{IO}

--- a/Rlabkey/man/labkey.provenance.addRecordingStep.Rd
+++ b/Rlabkey/man/labkey.provenance.addRecordingStep.Rd
@@ -34,14 +34,19 @@ The generated recording ID which can be used in subsequent steps (or queries tha
 ## start a provenance recording and add a recording step
 library(Rlabkey)
 
-mi <- data.frame(lsid=c("urn:lsid:labkey.com:Sample.251.MySamples:sample1", "urn:lsid:labkey.com:Sample.251.MySamples:sample2"))
+mi <- data.frame(lsid=c("urn:lsid:labkey.com:Sample.251.MySamples:sample1",
+        "urn:lsid:labkey.com:Sample.251.MySamples:sample2"))
 
-p <- labkey.provenance.createProvenanceParams(name="step1", description="initial step", materialInputs=mi)
-r <- labkey.provenance.startRecording(baseUrl="https://labkey.org/labkey/", folderPath = "Provenance", provenanceParams=p)
-do <- data.frame(lsid="urn:lsid:labkey.com:AssayRunTSVData.Folder-251:12c70994-7ce5-1038-82f0-9c1487dbd334")
+p <- labkey.provenance.createProvenanceParams(name="step1", description="initial step",
+        materialInputs=mi)
+r <- labkey.provenance.startRecording(baseUrl="https://labkey.org/labkey/",
+        folderPath = "Provenance", provenanceParams=p)
+do <- data.frame(
+        lsid="urn:lsid:labkey.com:AssayRunTSVData.Folder-251:12c70994-7ce5-1038-82f0-9c1487dbd334")
 
 labkey.provenance.addRecordingStep(baseUrl="https://labkey.org/labkey/", folderPath = "Provenance",
-    provenanceParams=labkey.provenance.createProvenanceParams(name="additional step", recordingId=r$recordingId, dataOutputs=do))
+    provenanceParams=labkey.provenance.createProvenanceParams(name="additional step",
+        recordingId=r$recordingId, dataOutputs=do))
 }
 }
 \keyword{IO}

--- a/Rlabkey/man/labkey.provenance.createProvenanceParams.Rd
+++ b/Rlabkey/man/labkey.provenance.createProvenanceParams.Rd
@@ -8,8 +8,8 @@ Note: this function is in beta and not yet final, changes should be expected so 
 \usage{
 labkey.provenance.createProvenanceParams(recordingId=NULL, name=NULL, description=NULL,
         materialInputs=NULL, materialOutputs=NULL, dataInputs=NULL, dataOutputs=NULL,
-        inputObjectUriProperty=NULL, outputObjectUriProperty=NULL, objectInputs=NULL, objectOutputs=NULL,
-        provenanceMap=NULL)
+        inputObjectUriProperty=NULL, outputObjectUriProperty=NULL, objectInputs=NULL,
+        objectOutputs=NULL, provenanceMap=NULL)
 }
 \arguments{
   \item{recordingId}{(optional) the recording ID to associate with other steps using the same ID}
@@ -17,6 +17,8 @@ labkey.provenance.createProvenanceParams(recordingId=NULL, name=NULL, descriptio
   \item{description}{(optional) the description of this provenance step}
   \item{materialInputs}{(optional) the list of materials (samples) to be used as the provenance run input. The data structure should be a dataframe with the column name describing the data type (lsid, id)}
   \item{materialOutputs}{(optional) the list of materials (samples) to be used as the provenance run output. The data structure should be a dataframe with the column name describing the data type (lsid, id)}
+  \item{dataInputs}{(optional) the list of data inputs to be used for the run provenance map}
+  \item{dataOutputs}{(optional) the list of data outputs to be used for the run provenance map}
   \item{inputObjectUriProperty}{(optional) for incoming data rows, the column name to interpret as the input to the provenance map. Defaults to : 'prov:objectInputs'}
   \item{outputObjectUriProperty}{(optional) for provenance mapping, the column name to interpret as the output to the provenance map. Defaults to : 'lsid'}
   \item{objectInputs}{(optional) the list of object inputs to be used for the run provenance map}
@@ -44,10 +46,13 @@ A list containing elements describing the passed in provenance parameters.
 ## create provenance params with material inputs and data outputs
 library(Rlabkey)
 
-mi <- data.frame(lsid=c("urn:lsid:labkey.com:Sample.251.MySamples:sample1", "urn:lsid:labkey.com:Sample.251.MySamples:sample2"))
-do <- data.frame(lsid="urn:lsid:labkey.com:AssayRunTSVData.Folder-251:12c70994-7ce5-1038-82f0-9c1487dbd334")
+mi <- data.frame(lsid=c("urn:lsid:labkey.com:Sample.251.MySamples:sample1",
+        "urn:lsid:labkey.com:Sample.251.MySamples:sample2"))
+do <- data.frame(
+        lsid="urn:lsid:labkey.com:AssayRunTSVData.Folder-251:12c70994-7ce5-1038-82f0-9c1487dbd334")
 
-p <- labkey.provenance.createProvenanceParams(name="step1", description="initial step", materialInputs=mi, dataOutputs=do)
+p <- labkey.provenance.createProvenanceParams(name="step1", description="initial step",
+        materialInputs=mi, dataOutputs=do)
 
 ## create provenance params with object inputs (from an assay run)
 oi <- labkey.selectRows(baseUrl="https://labkey.org/labkey/", folderPath = "Provenance",
@@ -55,9 +60,11 @@ oi <- labkey.selectRows(baseUrl="https://labkey.org/labkey/", folderPath = "Prov
         queryName="Data",
         colSelect= c("LSID"),
         colFilter=makeFilter(c("Run/RowId","EQUAL","253")))
-mi <- data.frame(lsid=c("urn:lsid:labkey.com:Sample.251.MySamples:sample1", "urn:lsid:labkey.com:Sample.251.MySamples:sample2"))
+mi <- data.frame(lsid=c("urn:lsid:labkey.com:Sample.251.MySamples:sample1",
+        "urn:lsid:labkey.com:Sample.251.MySamples:sample2"))
 
-p <- labkey.provenance.createProvenanceParams(name="step1", description="initial step", objectInputs=oi[["LSID"]], materialInputs=mi)
+p <- labkey.provenance.createProvenanceParams(name="step1", description="initial step",
+        objectInputs=oi[["LSID"]], materialInputs=mi)
 
 }
 }

--- a/Rlabkey/man/labkey.provenance.startRecording.Rd
+++ b/Rlabkey/man/labkey.provenance.startRecording.Rd
@@ -36,11 +36,15 @@ The generated recording ID which can be used in subsequent steps (or queries tha
 ## create provenance params with material inputs and data outputs and start a recording
 library(Rlabkey)
 
-mi <- data.frame(lsid=c("urn:lsid:labkey.com:Sample.251.MySamples:sample1", "urn:lsid:labkey.com:Sample.251.MySamples:sample2"))
-do <- data.frame(lsid="urn:lsid:labkey.com:AssayRunTSVData.Folder-251:12c70994-7ce5-1038-82f0-9c1487dbd334")
+mi <- data.frame(lsid=c("urn:lsid:labkey.com:Sample.251.MySamples:sample1",
+        "urn:lsid:labkey.com:Sample.251.MySamples:sample2"))
+do <- data.frame(
+        lsid="urn:lsid:labkey.com:AssayRunTSVData.Folder-251:12c70994-7ce5-1038-82f0-9c1487dbd334")
 
-p <- labkey.provenance.createProvenanceParams(name="step1", description="initial step", materialInputs=mi, dataOutputs=do)
-labkey.provenance.startRecording(baseUrl="https://labkey.org/labkey/", folderPath = "Provenance", provenanceParams=p)
+p <- labkey.provenance.createProvenanceParams(name="step1", description="initial step",
+        materialInputs=mi, dataOutputs=do)
+labkey.provenance.startRecording(baseUrl="https://labkey.org/labkey/",
+        folderPath = "Provenance", provenanceParams=p)
 }
 }
 \keyword{IO}

--- a/Rlabkey/man/labkey.provenance.stopRecording.Rd
+++ b/Rlabkey/man/labkey.provenance.stopRecording.Rd
@@ -41,12 +41,17 @@ oi <- labkey.selectRows(baseUrl="https://labkey.org/labkey/", folderPath = "Prov
         queryName="Data",
         colSelect= c("LSID"),
         colFilter=makeFilter(c("Run/RowId","EQUAL","253")))
-mi <- data.frame(lsid=c("urn:lsid:labkey.com:Sample.251.MySamples:sample1", "urn:lsid:labkey.com:Sample.251.MySamples:sample2"))
+mi <- data.frame(lsid=c("urn:lsid:labkey.com:Sample.251.MySamples:sample1",
+        "urn:lsid:labkey.com:Sample.251.MySamples:sample2"))
 
-p <- labkey.provenance.createProvenanceParams(name="step1", description="initial step", objectInputs=oi[["LSID"]], materialInputs=mi)
-r <- labkey.provenance.startRecording(baseUrl="https://labkey.org/labkey/", folderPath = "Provenance", provenanceParams=p)
-run <- labkey.provenance.stopRecording(baseUrl="https://labkey.org/labkey/", folderPath = "Provenance",
-    provenanceParams=labkey.provenance.createProvenanceParams(name="final step", recordingId=r$recordingId))
+p <- labkey.provenance.createProvenanceParams(name="step1", description="initial step",
+        objectInputs=oi[["LSID"]], materialInputs=mi)
+r <- labkey.provenance.startRecording(baseUrl="https://labkey.org/labkey/",
+        folderPath = "Provenance", provenanceParams=p)
+run <- labkey.provenance.stopRecording(baseUrl="https://labkey.org/labkey/",
+        folderPath = "Provenance",
+        provenanceParams=labkey.provenance.createProvenanceParams(name="final step",
+            recordingId=r$recordingId))
 }
 }
 \keyword{IO}


### PR DESCRIPTION
#### Rationale
While running the CRAN check on the new changes for Rlabkey version 2.5.0, there were a few warnings / notes related to the documentation files. These were mostly "line length" type issues.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-r/pull/51

#### Changes
* Fix for Rd doc file example line lengths > 100 chars
* Add missing arguments for labkey.provenance.createProvenanceParams.Rd 
