### PR TITLE
Add "donttest" for those man page examples that use internet resources / queries

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -5,7 +5,7 @@ Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>
 Description: The 'LabKey' client library for R makes it easy for R users to
-    load live data from a 'LabKey' Server, <http://www.labkey.com/>,
+    load live data from a 'LabKey' Server, <https://www.labkey.com/>,
     into the R environment for analysis, provided users have permissions
     to read the data. It also enables R users to insert, update, and
     delete records stored on a 'LabKey' Server, provided they have appropriate

--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 2.5.0
-Date: 2020-06-16
+Version: 2.5.1
+Date: 2020-07-08
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
 Version: 2.5.1
-Date: 2020-07-08
+Date: 2020-07-09
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,5 +1,6 @@
 Changes in 2.5.1
   o Add "donttest" for those man page examples that use internet resources / queries
+  o Fix type in filter name for labkey.domain.createConditionalFormatQueryFilter
 
 Changes in 2.5.0
   o Add support for creating provenance runs : createProvenanceParams, startRecording, addRecordingStep, stopRecording

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 2.5.1
+  o Add "donttest" for those man page examples that use internet resources / queries
+
 Changes in 2.5.0
   o Add support for creating provenance runs : createProvenanceParams, startRecording, addRecordingStep, stopRecording
   o Add provenance support to query APIs : insertRows, updateRows, deleteRows

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 2.4.0\cr
-Date: \tab 2020-04-03\cr
+Version: \tab 2.5.1\cr
+Date: \tab 2020-07-08\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -19,7 +19,7 @@ schema objects (\code{labkey.getSchema}).
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
 Version: \tab 2.5.1\cr
-Date: \tab 2020-07-08\cr
+Date: \tab 2020-07-09\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -58,7 +58,7 @@ Multiple such blocks can exist in one file.
 \author{Valerie Obenchain
 }
 \references{http://www.omegahat.net/RCurl/,\cr
-http://www.labkey.org/project/home/begin.view}
+https://www.labkey.org/project/home/begin.view}
 \keyword{ package }
 \seealso{
 \code{\link{labkey.selectRows}}, \code{\link{labkey.executeSql}}, \code{\link{makeFilter}}, 

--- a/Rlabkey/man/getFolderPath.Rd
+++ b/Rlabkey/man/getFolderPath.Rd
@@ -19,11 +19,13 @@ getFolderPath(session)
 \author{Peter Hussey}
 \seealso{\code{\link{getSession}}  \code{\link{lsFolders}}}
 \examples{
+\donttest{
 
 # library(Rlabkey)
 
-lks<- getSession("http://www.labkey.org", "/home")
+lks<- getSession("https://www.labkey.org", "/home")
 getFolderPath(lks)  #returns "/home"
 
+}
 }
 \keyword{file}

--- a/Rlabkey/man/getSession.Rd
+++ b/Rlabkey/man/getSession.Rd
@@ -45,7 +45,7 @@ The Rlabkey Users Guide is available by typing RlabkeyUsersGuide().
 
 # library(Rlabkey)
 
-s <- getSession("http://www.labkey.org", "/home")
+s <- getSession("https://www.labkey.org", "/home")
 s   #shows schemas
 
 ## using the curlOptions for generating debug tracesof network traffic

--- a/Rlabkey/man/labkey.getFolders.Rd
+++ b/Rlabkey/man/labkey.getFolders.Rd
@@ -45,12 +45,14 @@ The available folders are returned as a three-column data frame containing
 \code{\link{labkey.security.moveContainer}}
 }
 \examples{
+\donttest{
 
 ## List of folders 
 # library(Rlabkey)
 
-folders <- labkey.getFolders("http://www.labkey.org", "/home")
+folders <- labkey.getFolders("https://www.labkey.org", "/home")
 folders
 
+}
 }
 \keyword{IO}

--- a/Rlabkey/man/labkey.getQueries.Rd
+++ b/Rlabkey/man/labkey.getQueries.Rd
@@ -39,16 +39,18 @@ https://www.labkey.org/project/home/begin.view}
 
 }
 \examples{
+\donttest{
 
 ## List of queries in a schema
 # library(Rlabkey)
 
 queriesDF <- labkey.getQueries(
-	baseUrl="http://www.labkey.org",
+	baseUrl="https://www.labkey.org",
 	folderPath="/home",
 	schemaName="lists"
 )
 queriesDF
 
+}
 }
 \keyword{IO}

--- a/Rlabkey/man/lsFolders.Rd
+++ b/Rlabkey/man/lsFolders.Rd
@@ -19,14 +19,16 @@ lsFolders(session)
 \author{Peter Hussey}
 \seealso{\code{\link{getSession}}, \code{\link{lsProjects}}, \code{\link{lsSchemas}}}
 \examples{
+\donttest{
 
 ##get a list if projects and folders
 # library(Rlabkey)
 
-lks<- getSession("http://www.labkey.org", "/home")
+lks<- getSession("https://www.labkey.org", "/home")
 
 #returns values "/home" , "/home/_menus" , ...
 lsFolders(lks)
 
+}
 }
 \keyword{file}

--- a/Rlabkey/man/lsProjects.Rd
+++ b/Rlabkey/man/lsProjects.Rd
@@ -18,19 +18,18 @@ lsProjects(baseUrl)
 \author{Peter Hussey}
 \seealso{\code{\link{getSession}}, \code{\link{lsFolders}}, \code{\link{lsSchemas}}}
 \examples{
+\donttest{
 
 ## get list of projects on server, connect a session in one project,
 ## then list the folders in that project
 # library(Rlabkey)
 
-lsProjects("http://www.labkey.org")
+lsProjects("https://www.labkey.org")
 
-lkorg <- getSession("http://www.labkey.org", "/home")
+lkorg <- getSession("https://www.labkey.org", "/home")
 lsFolders(lkorg)
 
-\dontrun{
-
-lkorg <- getSession("http://www.labkey.org", "/home/Study/ListDemo")
+lkorg <- getSession("https://www.labkey.org", "/home/Study/ListDemo")
 lsSchemas(lkorg)
 
 }


### PR DESCRIPTION
#### Rationale
CRAN sent a message last week related to some ERRORs it hit when running some of the examples in the man doc pages for the Rlabkey package. It just so happened that the package submission that I did, which triggers CRAN to run the tests, coincided with a time when labkey.org was down. A few of our examples were using `http://www.labkey.org` as the baseUrl for various commands. 

#### Changes
* Change usages of `http://www.labkey.org` to `https://www.labkey.org`
* Add `donttest` to any of the examples which use API calls
