### PR TITLE
Fix for labkey.saveBatch URL encoding of assay name parameter, not needed with change to use labkey.post

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 2.5.1
-Date: 2020-07-09
+Version: 2.5.2
+Date: 2020-08-05
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 2.5.2
+  o Fix for labkey.saveBatch URL encoding of assay name parameter, not needed with change to use labkey.post
+
 Changes in 2.5.1
   o Add "donttest" for those man page examples that use internet resources / queries
   o Fix type in filter name for labkey.domain.createConditionalFormatQueryFilter

--- a/Rlabkey/R/labkey.saveBatch.R
+++ b/Rlabkey/R/labkey.saveBatch.R
@@ -28,13 +28,9 @@ labkey.saveBatch <- function(baseUrl=NULL, folderPath, assayName, resultDataFram
     ## normalize the folder path
     folderPath <- encodeFolderPath(folderPath)
 
-	## URL encode assay name (if not already encoded)
-	if(assayName==URLdecode(assayName)) {assayNameParam <- URLencode(assayName)}
-	else {assayNameParam <- assayName}
-
 	## Translate assay name to an ID
 	myurl <- paste(baseUrl,"assay",folderPath,"assayList.api", sep="")
-    params <- list(name=assayNameParam)
+    params <- list(name=assayName)
     assayInfoJSON <- labkey.post(myurl, toJSON(params, auto_unbox=TRUE))
 	assayDef <- NULL
 	assayInfo<- fromJSON(assayInfoJSON, simplifyVector=FALSE, simplifyDataFrame=FALSE)

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 2.5.1\cr
-Date: \tab 2020-07-09\cr
+Version: \tab 2.5.2\cr
+Date: \tab 2020-08-05\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }


### PR DESCRIPTION
#### Rationale
There was a regression with Rlabkey v2.4.0 when the labkey.saveBatch was changed from a GET to a POST. The assay name param was still being URLencoded even though we no longer what that for the post. Note: I did a review of other URL param encodings in the Rlabkey R code and this looks to be the only affected function.

See related ticket [40996](https://www.labkey.org/Optide/Support%20Tickets/issues-details.view?issueId=40996).

Here is the updated Rlabkey package version for local testing: [Rlabkey_2.5.2.tar.gz](https://github.com/LabKey/labkey-api-r/files/5030368/Rlabkey_2.5.2.tar.gz)

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/426

#### Changes
* labkey.saveBatch update to remove URLencode call for assay name param
