### PR TITLE
41071: Connect to multiple servers in one R session

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Rlabkey
-Version: 2.5.2
+Version: 2.5.3
 Date: 2020-08-05
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 

--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
 Version: 2.5.3
-Date: 2020-08-05
+Date: 2020-08-17
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 2.5.3
+  o Issue 41071: Support connecting to multiple LabKey servers in the same session.
+
 Changes in 2.5.2
   o Fix for labkey.saveBatch URL encoding of assay name parameter, not needed with change to use labkey.post
 


### PR DESCRIPTION
#### Rationale
The Rlabkey library does not support connecting to multiple servers within the same R session (or at least POST'ing to multiple servers). The reason is because we cache a single CSRF token and don't clear the cache when using a different base URL.

#### Related Issue
- https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41071

#### Changes
- Create a separate environment scope to hold CSRF tokens, keyed by the base URL
- Fixed an issue where getBaseUrl called with a default base URL would not allow resetting an existing URL
- Updated environment getters and setters to use the more succinct $ method over the prior [[ ]] method.
