### PR TITLE
Fix for labkey.domain.get to handle new "domainKindName" property null check

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 2.5.3
-Date: 2020-08-17
+Version: 2.5.4
+Date: 2020-11-03
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 2.5.4
+  o Fix for labkey.domain.get to handle new "domainKindName" property null check
+
 Changes in 2.5.3
   o Issue 41071: Support connecting to multiple LabKey servers in the same session.
 

--- a/Rlabkey/R/labkey.domain.R
+++ b/Rlabkey/R/labkey.domain.R
@@ -40,6 +40,7 @@ labkey.domain.get <- function(baseUrl=NULL, folderPath, schemaName, queryName)
     if (is.null(result$queryName)) result$queryName = NA
     if (is.null(result$templateDescription)) result$templateDescription = NA
     if (is.null(result$instructions)) result$instructions = NA
+    if (is.null(result$domainKindName)) result$domainKindName = NA
 
     return (result)
 }

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 2.5.2\cr
-Date: \tab 2020-08-05\cr
+Version: \tab 2.5.4\cr
+Date: \tab 2020-11-03\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }


### PR DESCRIPTION
#### Rationale
With the domain designer changes from the related PR to add the export/import functionality, there was a new "domainKindName" property added to the get domain API response. This new property needs a null check in the labkey.domain.get call.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1661

#### Changes
* labkey.domain.get null check for new "domainKindName" property to convert to NA
