### PR TITLE
SaveModulePropertiesAction: Eliminate validation check for unused userId parameter

### DIFF
--- a/Rlabkey/R/labkey.moduleProperty.R
+++ b/Rlabkey/R/labkey.moduleProperty.R
@@ -75,7 +75,7 @@ labkey.setModuleProperty <- function(baseUrl=NULL, folderPath, moduleName, propN
 
     property <- list()
     property$moduleName = moduleName
-    property$userId = 0 ##currently do not support individualized properties
+    property$userId = 0 ## Ignored and no longer required, as of 21.7. Remove this parameter once compatibility with < 21.7 is no longer needed.
     property$propName = propName
     property$value = propValue
     property$currentContainer = TRUE


### PR DESCRIPTION
#### Rationale
`SaveModulePropertiesAction` no longer requires a `userId` parameter

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2208

#### Changes
* Update comment about unused `userId` parameter -- we'll keep it around here for a while for backward compatibility purposes