### PR TITLE
Add ontology filters to makeFilter

### DIFF
--- a/Rlabkey/R/makeFilter.R
+++ b/Rlabkey/R/makeFilter.R
@@ -107,8 +107,13 @@
 								# Table/Query-wise operators
 								#
 
-								"Q"="q"
+								"Q"="q",
 
+                                #
+                                # Ontology filters
+                                #
+								"ONTOLOGY_IN_SUBTREE"="concept:insubtree",
+								"ONTOLOGY_NOT_IN_SUBTREE"="concept:notinsubtree",
 								)
 
  				if(is.null(fop)==TRUE) stop ("Invalid operator name.")

--- a/Rlabkey/R/makeFilter.R
+++ b/Rlabkey/R/makeFilter.R
@@ -109,9 +109,9 @@
 
 								"Q"="q",
 
-                                #
-                                # Ontology filters
-                                #
+								#
+								# Ontology filters
+								#
 								"ONTOLOGY_IN_SUBTREE"="concept:insubtree",
 								"ONTOLOGY_NOT_IN_SUBTREE"="concept:notinsubtree",
 								)

--- a/Rlabkey/man/makeFilter.Rd
+++ b/Rlabkey/man/makeFilter.Rd
@@ -51,6 +51,8 @@ NOT_MISSING\cr
 MV_INDICATOR\cr
 NO_MV_INDICATOR\cr
 Q\cr
+ONTOLOGY_IN_SUBTREE\cr
+ONTOLOGY_NOT_IN_SUBTREE\cr
 
 When using the MISSING, NOT_MISSING, MV_INDICATOR, or NO_MV_INDICATOR operators, an empty string should be supplied as the value.
 See example below.


### PR DESCRIPTION
#### Rationale
Item #8670 - https://docs.google.com/document/d/1QmHYktA4uNPxiSeid1kX2TakE2E0QPU4ZBkuSwTNeZI/edit?usp=sharing
Ontology, data region column filtering

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2205

#### Changes
* Added Filter.Types.ONTOLOGY_NOT_IN_SUBTREE and Filter.Types.ONTOLOGY_IN_SUBTREE
