### PR TITLE
Rlabkey v2.7.0 - version bump and release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Install tools needed for building R packages. [Build tools](https://cran.r-proje
 
 After all tools are installed, run `./gradlew build`.
 
+If you encounter any LaTex related errors during the `build` or `check` steps, try the following:
+- See installation docs from [https://yihui.name/tinytex/](https://yihui.name/tinytex/).
+  - `curl -sL "https://yihui.name/gh/tinytex/tools/install-unx.sh" | sh`
+- For an error like `! LaTeX Error: File 'longtable.sty' not found.`
+  - `tlmgr search --global --file "/longtable.sty"`
+  - `tlmgr install latex-tools`
+
 ## Installing
 
 `./gradlew installRLabkey` will install Rlabkey and its dependencies into your user's package library (`R_LIBS_USER`)

--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 2.6.0
-Date: 2021-02-02
+Version: 2.7.0
+Date: 2021-05-19
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,10 @@
+Changes in 2.7.0
+  o Add ontology filter types to makeFilter
+  o Issue 43107: Fix for labkey.domain.createAndLoad to set strictFieldValidation to false for study datasets and data classes
+  o Issue 42950: Add param to labkey.webdav.put for setting the file description
+  o Issue 42546: Add new labkey.query.import command which uses file import to bulk import rows to a query/table
+  o Update labkey.domain.createAndLoad to use the new labkey.query.import command for the bulk data import
+
 Changes in 2.6.0
   o Add labkey.pipeline functions to be able to get pipeline protocol information and start jobs / analysis
 

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 2.6.0\cr
-Date: \tab 2021-02-02\cr
+Version: \tab 2.7.0\cr
+Date: \tab 2021-05-19\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }

--- a/Rlabkey/man/labkey.setCurlOptions.Rd
+++ b/Rlabkey/man/labkey.setCurlOptions.Rd
@@ -57,9 +57,7 @@ Under System Variables click on the new button.\cr
 For Variable Name: enter RLABKEY_CAINFO_FILE\cr
 For Variable Value: enter the path of the ca-bundle.crt you created above.\cr
 Hit the Ok buttons to close all the windows.\cr
-Now you can start R and begin working.
-
-\cr \cr
+Now you can start R and begin working.\cr
 
 This command can also be used to provide an alternate location / path to your
 \code{.netrc} file. Example:\cr


### PR DESCRIPTION
#### Rationale
See related PRs for the changes that are included in this Rlabkey version bump. This PR just bumps the version and adds the release notes info.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-r/pull/66
* https://github.com/LabKey/labkey-api-r/pull/68

#### Changes
* Update Rlabkey package version to 2.7.0
* Add release notes for related changes
* Update README related to LaTex build issue triage
* Fix for CRAN error with Rd file