### PR TITLE
Issue 43890: Fix for makeDF rname string concatenation

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 2.8.0
-Date: 2021-07-07
+Version: 2.8.1
+Date: 2021-09-10
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,5 +1,6 @@
 Changes in 2.8.1
   o Issue 43890: Fix for makeDF rname string concatenation
+  o Issue 43853: Update error message for labkey.getModuleProperty() call when user does not have perm to requested container
 
 Changes in 2.8.0
   o Issue 43358: Add support for impersonating users (labkey.security.impersonateUser and labkey.security.stopImpersonating)

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 2.8.1
+  o Issue 43890: Fix for makeDF rname string concatenation
+
 Changes in 2.8.0
   o Issue 43358: Add support for impersonating users (labkey.security.impersonateUser and labkey.security.stopImpersonating)
 

--- a/Rlabkey/R/labkey.moduleProperty.R
+++ b/Rlabkey/R/labkey.moduleProperty.R
@@ -36,6 +36,10 @@ labkey.getModuleProperty <- function(baseUrl=NULL, folderPath, moduleName, propN
     if (exists("response"))
     {
         result <- (fromJSON(response))
+        if (is.null(result$id))
+        {
+            return ("User does not have permission to perform this operation")
+        }
         if (is.null(result$moduleProperties))
         {
             return (paste("Module property does not exist for", moduleName, "module in folder", folderPath))

--- a/Rlabkey/R/makeDF.R
+++ b/Rlabkey/R/makeDF.R
@@ -203,7 +203,7 @@ return(filtered)
 			if(length(existing[rname == existing]) ==0)
 				{break;}
 			else 
-				{rname<- c(rname + as.character(i))}
+				{rname<- c(paste0(rname, i))}
         } 
   	}    	
   	return (rname)

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 2.8.0\cr
-Date: \tab 2021-07-07\cr
+Version: \tab 2.8.1\cr
+Date: \tab 2021-09-10\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43890
When a query/table has a PK field that has a space in it, the response object contains duplicate information regarding the column info for that field. In this case, the Rlabkey package response parsing code attempts to make a unique data.frame column name for the field by appending an integer to the field name. However, there was a long standing issue in this Rlabkey string concat code which was not properly using the paste0() function but was instead trying to concat them via "+".

#### Changes
* Fix makeDF rname string concatenation to use paste0()
* Update labkey.getModuleProperties() error message for case when user does not have perm to the requested container
