### PR TITLE
Support for run name when creating a provenance run

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 2.8.1
-Date: 2021-09-10
+Version: 2.8.2
+Date: 2021-11-30
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 2.8.2
+  o Issue 44110: Allow specification of a run name in the provenance API.
+
 Changes in 2.8.1
   o Issue 43890: Fix for makeDF rname string concatenation
   o Issue 43853: Update error message for labkey.getModuleProperty() call when user does not have perm to requested container

--- a/Rlabkey/R/labkey.provenance.R
+++ b/Rlabkey/R/labkey.provenance.R
@@ -18,7 +18,7 @@
 ## provenance functions
 ##
 labkey.provenance.createProvenanceParams <- function(recordingId=NULL, name=NULL, description=NULL,
-        materialInputs=NULL, materialOutputs=NULL, dataInputs=NULL, dataOutputs=NULL,
+        runName=NULL, materialInputs=NULL, materialOutputs=NULL, dataInputs=NULL, dataOutputs=NULL,
         inputObjectUriProperty=NULL, outputObjectUriProperty=NULL, objectInputs=NULL, objectOutputs=NULL,
         provenanceMap=NULL)
 {
@@ -30,6 +30,8 @@ labkey.provenance.createProvenanceParams <- function(recordingId=NULL, name=NULL
         param$name = name
     if (!missing(description))
         param$description = description
+    if (!missing(runName))
+        param$runName = runName
 
     if (!missing(materialInputs))
     {

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 2.8.1\cr
-Date: \tab 2021-09-10\cr
+Version: \tab 2.8.2\cr
+Date: \tab 2021-11-30\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }

--- a/Rlabkey/man/labkey.provenance.createProvenanceParams.Rd
+++ b/Rlabkey/man/labkey.provenance.createProvenanceParams.Rd
@@ -7,7 +7,7 @@ Note: this function is in beta and not yet final, changes should be expected so 
 }
 \usage{
 labkey.provenance.createProvenanceParams(recordingId=NULL, name=NULL, description=NULL,
-        materialInputs=NULL, materialOutputs=NULL, dataInputs=NULL, dataOutputs=NULL,
+        runName=NULL, materialInputs=NULL, materialOutputs=NULL, dataInputs=NULL, dataOutputs=NULL,
         inputObjectUriProperty=NULL, outputObjectUriProperty=NULL, objectInputs=NULL,
         objectOutputs=NULL, provenanceMap=NULL)
 }
@@ -15,6 +15,7 @@ labkey.provenance.createProvenanceParams(recordingId=NULL, name=NULL, descriptio
   \item{recordingId}{(optional) the recording ID to associate with other steps using the same ID}
   \item{name}{(optional) the name of this provenance step}
   \item{description}{(optional) the description of this provenance step}
+  \item{runName}{(optional) the name of the provenance run, if none if specified a default run name will be created}
   \item{materialInputs}{(optional) the list of materials (samples) to be used as the provenance run input. The data structure should be a dataframe with the column name describing the data type (lsid, id)}
   \item{materialOutputs}{(optional) the list of materials (samples) to be used as the provenance run output. The data structure should be a dataframe with the column name describing the data type (lsid, id)}
   \item{dataInputs}{(optional) the list of data inputs to be used for the run provenance map}

--- a/Rlabkey/man/labkey.provenance.createProvenanceParams.Rd
+++ b/Rlabkey/man/labkey.provenance.createProvenanceParams.Rd
@@ -15,7 +15,7 @@ labkey.provenance.createProvenanceParams(recordingId=NULL, name=NULL, descriptio
   \item{recordingId}{(optional) the recording ID to associate with other steps using the same ID}
   \item{name}{(optional) the name of this provenance step}
   \item{description}{(optional) the description of this provenance step}
-  \item{runName}{(optional) the name of the provenance run, if none if specified a default run name will be created}
+  \item{runName}{(optional) the name of the provenance run, if none specified a default run name will be created}
   \item{materialInputs}{(optional) the list of materials (samples) to be used as the provenance run input. The data structure should be a dataframe with the column name describing the data type (lsid, id)}
   \item{materialOutputs}{(optional) the list of materials (samples) to be used as the provenance run output. The data structure should be a dataframe with the column name describing the data type (lsid, id)}
   \item{dataInputs}{(optional) the list of data inputs to be used for the run provenance map}

--- a/Rlabkey/man/labkey.provenance.stopRecording.Rd
+++ b/Rlabkey/man/labkey.provenance.stopRecording.Rd
@@ -11,7 +11,7 @@ labkey.provenance.stopRecording(baseUrl=NULL, folderPath, provenanceParams = NUL
 \arguments{
   \item{baseUrl}{a string specifying the \code{baseUrl} for the labkey server}
   \item{folderPath}{a string specifying the \code{folderPath} }
-  \item{provenanceParams}{the provenance parameter object which contains the options to include in this recording step}
+  \item{provenanceParams}{the provenance parameter object which contains the options to include in this recording step, including the recording ID}
 }
 \details{
 Function to stop the provenance recording associated with the recording ID, this will create a provenance run


### PR DESCRIPTION
#### Rationale
We recently added support on the server to accept an optional run name when creating a provenance run through the API. We need to update the Rlabkey API to allow the new property to be threaded through to the request.

#### Changes
- Update `labkey.provenance.createProvenanceParams` to accept an optional runName parameter
- Update docs and readme