### PR TITLE
Rlabkey v2.8.2 - fix for CRAN check regarding "usage lines wider than 90 characters"

### DIFF
--- a/Rlabkey/man/labkey.provenance.createProvenanceParams.Rd
+++ b/Rlabkey/man/labkey.provenance.createProvenanceParams.Rd
@@ -7,9 +7,9 @@ Note: this function is in beta and not yet final, changes should be expected so 
 }
 \usage{
 labkey.provenance.createProvenanceParams(recordingId=NULL, name=NULL, description=NULL,
-        runName=NULL, materialInputs=NULL, materialOutputs=NULL, dataInputs=NULL, dataOutputs=NULL,
-        inputObjectUriProperty=NULL, outputObjectUriProperty=NULL, objectInputs=NULL,
-        objectOutputs=NULL, provenanceMap=NULL)
+        runName=NULL, materialInputs=NULL, materialOutputs=NULL, dataInputs=NULL,
+        dataOutputs=NULL, inputObjectUriProperty=NULL, outputObjectUriProperty=NULL,
+        objectInputs=NULL, objectOutputs=NULL, provenanceMap=NULL)
 }
 \arguments{
   \item{recordingId}{(optional) the recording ID to associate with other steps using the same ID}


### PR DESCRIPTION
#### Rationale
Minor issue found during local CRAN check:
```
* checking Rd line widths ... NOTE
Rd file 'labkey.provenance.createProvenanceParams.Rd':
  \usage lines wider than 90 characters:
             runName=NULL, materialInputs=NULL, materialOutputs=NULL, dataInputs=NULL, dataOutputs=NULL,

These lines will be truncated in the PDF manual.
```

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-r/pull/73

#### Changes
* R doc fix for usage text
