### PR TITLE
Issue 44619: labkey.getFolders() update to account for missing properties if the parent is root

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 2.8.2
-Date: 2021-11-30
+Version: 2.8.3
+Date: 2022-02-24
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 2.8.3
+  o Issue 44619: labkey.getFolders() update to account for missing properties if the parent is root
+
 Changes in 2.8.2
   o Issue 44110: Allow specification of a run name in the provenance API.
 

--- a/Rlabkey/R/labkey.getFolders.R
+++ b/Rlabkey/R/labkey.getFolders.R
@@ -40,6 +40,14 @@ labkey.getFolders <- function(baseUrl=NULL, folderPath, includeEffectivePermissi
 
 	curfld <- decode
 	curfld$effectivePermissions = paste(curfld$effectivePermissions, collapse=",")
+
+    # Issue 44619: account for missing properties if the parent is root
+    for (col in resultCols) {
+        if (is.null(curfld[[col]])) {
+            curfld[[col]] = "";
+        }
+    }
+
 	allpaths <- matrix(data=unlist(curfld[resultCols]), nrow=1, ncol=length(resultCols), byrow=TRUE)
 	childflds <- curfld$children[]
 	while (length(childflds)>0)

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 2.8.2\cr
-Date: \tab 2021-11-30\cr
+Version: \tab 2.8.3\cr
+Date: \tab 2022-02-24\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44619

#### Changes
* Update labkey.getFolder() JSON parsing code to ensure that all expected properties exist before creating data.frame
