### PR TITLE
Display custom run step properties in the lineage graph

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 2.8.3
-Date: 2022-02-24
+Version: 2.8.4
+Date: 2022-03-24
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 2.8.4
+  o Update labkey.provenance.createProvenanceParams to support custom properties (and standard run step properties)
+
 Changes in 2.8.3
   o Issue 44619: labkey.getFolders() update to account for missing properties if the parent is root
 

--- a/Rlabkey/R/labkey.provenance.R
+++ b/Rlabkey/R/labkey.provenance.R
@@ -20,10 +20,12 @@
 labkey.provenance.createProvenanceParams <- function(recordingId=NULL, name=NULL, description=NULL,
         runName=NULL, materialInputs=NULL, materialOutputs=NULL, dataInputs=NULL, dataOutputs=NULL,
         inputObjectUriProperty=NULL, outputObjectUriProperty=NULL, objectInputs=NULL, objectOutputs=NULL,
-        provenanceMap=NULL)
+        provenanceMap=NULL, params=NULL, properties=NULL)
 {
     param <- list()
 
+    if (!missing(params))
+        param <- params
     if (!missing(recordingId))
         param$recordingId = recordingId
     if (!missing(name))
@@ -63,6 +65,14 @@ labkey.provenance.createProvenanceParams <- function(recordingId=NULL, name=NULL
             stop (paste("The 'dataOutputs' parameter must be a list of data outputs."))
 
         param$dataOutputs = dataOutputs
+    }
+
+    if (!missing(properties))
+    {
+        if (!is.list(properties))
+            stop (paste("The 'properties' parameter must be a list of property URIs to values."))
+
+        param$properties = properties
     }
 
     if (!missing(inputObjectUriProperty))

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 2.8.3\cr
-Date: \tab 2022-02-24\cr
+Version: \tab 2.8.4\cr
+Date: \tab 2022-03-24\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }

--- a/Rlabkey/man/labkey.provenance.createProvenanceParams.Rd
+++ b/Rlabkey/man/labkey.provenance.createProvenanceParams.Rd
@@ -9,7 +9,8 @@ Note: this function is in beta and not yet final, changes should be expected so 
 labkey.provenance.createProvenanceParams(recordingId=NULL, name=NULL, description=NULL,
         runName=NULL, materialInputs=NULL, materialOutputs=NULL, dataInputs=NULL,
         dataOutputs=NULL, inputObjectUriProperty=NULL, outputObjectUriProperty=NULL,
-        objectInputs=NULL, objectOutputs=NULL, provenanceMap=NULL, params=NULL, properties=NULL)
+        objectInputs=NULL, objectOutputs=NULL, provenanceMap=NULL,
+        params=NULL, properties=NULL)
 }
 \arguments{
   \item{recordingId}{(optional) the recording ID to associate with other steps using the same ID}
@@ -72,7 +73,8 @@ p <- labkey.provenance.createProvenanceParams(name="step1", description="initial
 ## add run step properties and custom properties to the provenance params
 props <- data.frame(
     "urn:lsid:labkey.com:Vocabulary.Folder-996:ProvenanceDomain#version"=c(22.3),
-    "urn:lsid:labkey.com:Vocabulary.Folder-996:ProvenanceDomain#instrumentName"=c("NAb plate reader"), check.names=FALSE)
+    "urn:lsid:labkey.com:Vocabulary.Folder-996:ProvenanceDomain#instrumentName"=c("NAb reader"),
+    check.names=FALSE)
 params <- list()
 params$comments <- "adding additional step properties"
 params$activityDate <- "2022-3-21"

--- a/Rlabkey/man/labkey.provenance.createProvenanceParams.Rd
+++ b/Rlabkey/man/labkey.provenance.createProvenanceParams.Rd
@@ -9,7 +9,7 @@ Note: this function is in beta and not yet final, changes should be expected so 
 labkey.provenance.createProvenanceParams(recordingId=NULL, name=NULL, description=NULL,
         runName=NULL, materialInputs=NULL, materialOutputs=NULL, dataInputs=NULL,
         dataOutputs=NULL, inputObjectUriProperty=NULL, outputObjectUriProperty=NULL,
-        objectInputs=NULL, objectOutputs=NULL, provenanceMap=NULL)
+        objectInputs=NULL, objectOutputs=NULL, provenanceMap=NULL, params=NULL, properties=NULL)
 }
 \arguments{
   \item{recordingId}{(optional) the recording ID to associate with other steps using the same ID}
@@ -25,6 +25,8 @@ labkey.provenance.createProvenanceParams(recordingId=NULL, name=NULL, descriptio
   \item{objectInputs}{(optional) the list of object inputs to be used for the run provenance map}
   \item{objectOutputs}{(optional) the list of object outputs to be used for the run provenance map}
   \item{provenanceMap}{(optional) the provenance map to be used directly for the run step. The data structure should be a dataframe with the column names of 'from' and 'to' to indicate which sides of the mapping the identifiers refer to}
+  \item{params}{(optional) the list of initial run step parameters. Parameters supported in the parameter list such as name, description, runName, can be specified in this data structure as well as other run step parameters not available in the parameter list}
+  \item{properties}{(optional) custom property values to associate with the run step. The data structure should be a dataframe with the property URIs as column names and the column value to associate with the property. The Vocabulary domain and fields must have been created prior to using}
 }
 \details{
 This function can be used to generate a provenance parameter object which can then be used as an argument
@@ -66,6 +68,18 @@ mi <- data.frame(lsid=c("urn:lsid:labkey.com:Sample.251.MySamples:sample1",
 
 p <- labkey.provenance.createProvenanceParams(name="step1", description="initial step",
         objectInputs=oi[["LSID"]], materialInputs=mi)
+
+## add run step properties and custom properties to the provenance params
+props <- data.frame(
+    "urn:lsid:labkey.com:Vocabulary.Folder-996:ProvenanceDomain#version"=c(22.3),
+    "urn:lsid:labkey.com:Vocabulary.Folder-996:ProvenanceDomain#instrumentName"=c("NAb plate reader"), check.names=FALSE)
+params <- list()
+params$comments <- "adding additional step properties"
+params$activityDate <- "2022-3-21"
+params$startTime <- "2022-3-21 12:35:00"
+params$endTime <- "2022-3-22 02:15:30"
+params$recordCount <- 2
+p <- labkey.provenance.createProvenanceParams(recordingId=ra$recordingId, name="step2", properties=props, params=params)
 
 }
 }

--- a/Rlabkey/man/labkey.provenance.createProvenanceParams.Rd
+++ b/Rlabkey/man/labkey.provenance.createProvenanceParams.Rd
@@ -81,7 +81,8 @@ params$activityDate <- "2022-3-21"
 params$startTime <- "2022-3-21 12:35:00"
 params$endTime <- "2022-3-22 02:15:30"
 params$recordCount <- 2
-p <- labkey.provenance.createProvenanceParams(recordingId=ra$recordingId, name="step2", properties=props, params=params)
+p <- labkey.provenance.createProvenanceParams(recordingId=ra$recordingId, name="step2",
+    properties=props, params=params)
 
 }
 }


### PR DESCRIPTION
#### Rationale
The Provenance API currently supports adding custom property values to a run step. The custom properties would be bound to an existing `Vocabulary` domain and while the server side code was persisting data to the database we did not surface them back to the lineage graph. 

This change updates the `Rlabkey` library to allow users to specify custom property values in the Provenance API.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/3177
https://github.com/LabKey/provenance/pull/97
https://github.com/LabKey/labkey-ui-components/pull/781

#### Changes
- Update `labkey.provenance.createProvenanceParams` to support optional parameters for custom property values as well as other run step standard properties that aren't specifically in the parameter list.