### PR TITLE
Update Ruminex dependencies

### DIFF
--- a/test/install-ruminex-dependencies.R
+++ b/test/install-ruminex-dependencies.R
@@ -16,8 +16,8 @@
 
 source("install-util.R")
 OS.type <- .Platform$OS.type
-if (OS.type == "unix") {
-    # Workaround for https://github.com/jyypma/nloptr/issues/40
-    install.dependencies("nloptr", github_deps=c("jyypma/nloptr"))
-}
-install.dependencies("Ruminex", c("drc", "xtable", "alr3", "Cairo", "plotrix"))
+# if (OS.type == "unix") {
+#     # Workaround for https://github.com/jyypma/nloptr/issues/40
+#     install.dependencies("nloptr", github_deps=c("jyypma/nloptr"))
+# }
+install.dependencies("Ruminex", c("drc", "xtable", "alr3", "Cairo", "plotrix", "vctrs", "nloptr"))

--- a/test/install-ruminex-dependencies.R
+++ b/test/install-ruminex-dependencies.R
@@ -20,4 +20,4 @@ OS.type <- .Platform$OS.type
 #     # Workaround for https://github.com/jyypma/nloptr/issues/40
 #     install.dependencies("nloptr", github_deps=c("jyypma/nloptr"))
 # }
-install.dependencies("Ruminex", c("drc", "xtable", "alr3", "Cairo", "plotrix", "vctrs", "nloptr"))
+install.dependencies("Ruminex", c("vctrs", "nloptr", "drc", "xtable", "alr3", "Cairo", "plotrix"))


### PR DESCRIPTION
#### Rationale
TeamCity has been failing to build R dependencies:
```
[ant:exec] ERROR: configuration failed for package ‘nloptr’
[ant:exec] * removing ‘/mnt/teamcity/work/8c0375c4fe0a826b/r_libs/nloptr’
[ant:exec] Warning messages:
[ant:exec] 1: The package `vctrs` (>= 0.3.8) is required as of rlang 1.0.0.
[ant:exec] 2: In i.p(...) :
```
I think this means we need to explicitly install 'vctrs'.

#### Changes
* Explicitly install `vctrs`
* Switch `nloptr` to use standard install method. Referenced issue claims to be closed.
