### PR TITLE
Update user agent for consistency with other LabKey client libraries

### DIFF
--- a/Rlabkey/R/labkey.setCurlOptions.R
+++ b/Rlabkey/R/labkey.setCurlOptions.R
@@ -32,7 +32,7 @@ labkey.setCurlOptions <- function(...)
     }
 
     # default curl options
-    options <- config(ssl_verifyhost=2, ssl_verifypeer=TRUE, followlocation=TRUE, sslversion=1L, useragent = "Rlabkey")
+    options <- config(ssl_verifyhost=2, ssl_verifypeer=TRUE, followlocation=TRUE, sslversion=1L, useragent = "LabKey R API")
 
     # check if a certificate bundle has been specified from the environment variable
     vars <- Sys.getenv("RLABKEY_CAINFO_FILE")


### PR DESCRIPTION
#### Rationale
We're moving all the LabKey client libraries to send a consistent user agent string to ease metrics gathering

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3533
