### PR TITLE
Freezer Manager API - add Primary Storage option to storage related action documentation

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 2.9.0
-Date: 2022-09-15
+Version: 2.9.1
+Date: 2022-12-15
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,5 +1,5 @@
 Changes in 2.9.1
-  o Freezer Manager API - add Primary Storage option to storage related action documentation
+  o Freezer Manager API - add Primary Storage option to storage-related action documentation
 
 Changes in 2.9.0
   o Add support for creating Freezer Manager freezer hierarchies

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 2.9.1
+  o Freezer Manager API - add Primary Storage option to storage related action documentation
+
 Changes in 2.9.0
   o Add support for creating Freezer Manager freezer hierarchies
   o New labkey.storage NAMESPACE: labkey.storage.create, labkey.storage.update, labkey.storage.delete

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 2.9.0\cr
-Date: \tab 2022-09-15\cr
+Version: \tab 2.9.1\cr
+Date: \tab 2022-12-15\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }

--- a/Rlabkey/man/labkey.storage.create.Rd
+++ b/Rlabkey/man/labkey.storage.create.Rd
@@ -2,8 +2,8 @@
 \alias{labkey.storage.create}
 \title{Create a new LabKey Freezer Manager storage item}
 \description{
-Create a new LabKey Freezer Manager storage item that can be used in the creation of a freezer hierarchy.
-Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister,
+Create a new LabKey Freezer Manager storage item that can be used in the creation of a storage hierarchy.
+Storage items can be of the following types: Physical Location, Freezer, Primary Storage, Shelf, Rack, Canister,
 Storage Unit Type, or Terminal Storage Location.
 }
 \usage{

--- a/Rlabkey/man/labkey.storage.delete.Rd
+++ b/Rlabkey/man/labkey.storage.delete.Rd
@@ -2,10 +2,10 @@
 \alias{labkey.storage.delete}
 \title{Delete a LabKey Freezer Manager storage item}
 \description{
-Delete an existing LabKey Freezer Manager storage item. Note that deletion of freezers or locations within the
-freezer hierarchy will cascade the delete down the hierarchy to remove child locations and terminal storage locations.
-Samples in the deleted freezer location(s) will not be deleted but will be removed from storage.
-Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister,
+Delete an existing LabKey Freezer Manager storage item. Note that deletion of freezers, primary storage, or locations
+within the storage hierarchy will cascade the delete down the hierarchy to remove child locations and terminal storage
+locations. Samples in the deleted storage location(s) will not be deleted but will be removed from storage.
+Storage items can be of the following types: Physical Location, Freezer, Primary Storage, Shelf, Rack, Canister,
 Storage Unit Type, or Terminal Storage Location.
 }
 \usage{

--- a/Rlabkey/man/labkey.storage.update.Rd
+++ b/Rlabkey/man/labkey.storage.update.Rd
@@ -2,8 +2,8 @@
 \alias{labkey.storage.update}
 \title{Update a LabKey Freezer Manager storage item}
 \description{
-Update an existing LabKey Freezer Manager storage item to change its properties or location within the freezer hierarchy.
-Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister,
+Update an existing LabKey Freezer Manager storage item to change its properties or location within the storage hierarchy.
+Storage items can be of the following types: Physical Location, Freezer, Primary Storage, Shelf, Rack, Canister,
 Storage Unit Type, or Terminal Storage Location.
 }
 \usage{


### PR DESCRIPTION
#### Rationale
See related PR for rationale. This PR updates the doc info for the storage APIs to include the new location type of "Primary Storage".

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/648

#### Changes
* add Primary Storage option to storage related action documentation
