### PR TITLE
Update content related to API/session keys

### DIFF
--- a/Rlabkey/man/labkey.setDefaults.Rd
+++ b/Rlabkey/man/labkey.setDefaults.Rd
@@ -9,37 +9,50 @@ these settings.}
 labkey.setDefaults(apiKey="", baseUrl="", email="", password="")
 }
 \arguments{
-  \item{apiKey}{session key from your server}
+  \item{apiKey}{api or session key from your server}
   \item{baseUrl}{server location including context path, if any. e.g. https://www.labkey.org/}
   \item{email}{user email address}
   \item{password}{user password}
 }
 
 \details{
-Note: Support for API keys was added in LabKey Server release 16.2; they are not supported in 16.1 or earlier.
-
-An API key can be used to authorize Rlabkey functions that access protected content on LabKey Server. Using an API key
-avoids copying and storing credentials on the client machine. Also, all Rlabkey access is tied to the current browser
-session, which means the code runs in the same context as the browser (e.g. same user, same authorizations, same
-declared terms of use and PHI level, same impersonation state, etc.).\cr
+An API key can be used to authorize Rlabkey functions that access secure content on LabKey Server. Using an API key
+avoids copying and storing credentials on the client machine. An API key can be revoked and set to expire. It also
+acts as a credential for those who sign in using a single sign-on authentication mechanism such as CAS or SAML.\cr
 
 A site administrator must first enable the use of API keys on that LabKey Server. Once enabled, any logged in user can
-generate an API key by clicking their display name (upper right) and selecting "API Keys". The API Key page creates
-and displays keys that can be copied and pasted into a labkey.setDefaults() statement to tie an Rlabkey session to the
-authorization and session information already set in the browser.\cr
+generate an API key by clicking their display name (upper right) and selecting "External Tool Access". The API Key page
+creates and displays keys that can be copied and pasted into a labkey.setDefaults() statement to give an Rlabkey
+session the permissions of the corresponding user.\cr
 
 If an API key is not provided, you can also use this function for basic authentication via email and password. Note
-that both email and password must be set via a labkey.setDefaults() call. If an apiKey is also set, that will be given
-preference and the email/password will not be used for authentication. Once authenticated via email/password, you
-can make multiple labkey.get or labkey.post API calls using that same connection.\cr
+that both email and password must be set via a labkey.setDefaults() call. If an API key is also set, that will be given
+preference and the email/password will not be used for authentication.\cr
+
+On servers that enable them, a session key can be used in place of an API key. A session key ties all Rlabkey access
+to a user's current browser session, which means the code runs in the same context as the browser (e.g. same user,
+same authorizations, same declared terms of use and PHI level, same impersonation state, etc.). Session keys can be
+useful in certain compliance scenarios.\cr
+
+Once valid credentials are provided to labkey.setDefaults(), subsequent labkey.get or labkey.post API calls will
+authenticate using those credentials.\cr
 }
 \examples{
 
-## Example of setting and clearing an API key and/or email/password.
+## Example of setting and clearing email/password, API key, and Session key
 # library(Rlabkey)
 
-labkey.setDefaults(apiKey="session|abcdef0123456789abcdef0123456789")
 labkey.setDefaults(email="testing@localhost.test", password="password")
+
+## Functions invoked at this point respect the role assignments and
+## other authorizations of the specified user
+
+labkey.setDefaults(apiKey="apikey|abcdef0123456789abcdef0123456789")
+
+## Functions invoked at this point respect the role assignments and
+## other authorizations of the user who created the API key
+
+labkey.setDefaults(apiKey="session|abcdef0123456789abcdef0123456789")
 
 ## Functions invoked at this point share authorization
 ## and session information with the browser session


### PR DESCRIPTION
#### Rationale
`labkey.setDefaults()` docs are out-of-date WRT API keys and session keys

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47182