### PR TITLE
Update test dependencies to build with R 4.x

### DIFF
--- a/test/install-ehr-dependencies.R
+++ b/test/install-ehr-dependencies.R
@@ -15,5 +15,5 @@
 ##
 
 source("install-util.R")
-install.dependencies("kinship2", c("getopt", "Matrix", "quadprog", "kinship2"))
+install.dependencies("kinship2", c("getopt", "Matrix", "quadprog", "kinship2", "dplyr"))
 install.dependencies("pedigree", c("HaploSim", "reshape", "pedigree"))

--- a/test/install-luminex-dependencies.R
+++ b/test/install-luminex-dependencies.R
@@ -15,9 +15,4 @@
 ##
 
 source("install-util.R")
-# OS.type <- .Platform$OS.type
-# if (OS.type == "unix") {
-#     # Workaround for https://github.com/jyypma/nloptr/issues/40
-#     install.dependencies("nloptr", github_deps=c("jyypma/nloptr"))
-# }
 install.dependencies("luminex", c("drc", "xtable", "Cairo", "plotrix"))

--- a/test/install-luminex-dependencies.R
+++ b/test/install-luminex-dependencies.R
@@ -15,4 +15,9 @@
 ##
 
 source("install-util.R")
+OS.type <- .Platform$OS.type
+if (OS.type == "unix") {
+    # Workaround for https://github.com/jyypma/nloptr/issues/40
+    install.dependencies("nloptr", github_deps=c("jyypma/nloptr"))
+}
 install.dependencies("luminex", c("drc", "xtable", "Cairo", "plotrix"))

--- a/test/install-luminex-dependencies.R
+++ b/test/install-luminex-dependencies.R
@@ -15,9 +15,9 @@
 ##
 
 source("install-util.R")
-OS.type <- .Platform$OS.type
-if (OS.type == "unix") {
-    # Workaround for https://github.com/jyypma/nloptr/issues/40
-    install.dependencies("nloptr", github_deps=c("jyypma/nloptr"))
-}
+# OS.type <- .Platform$OS.type
+# if (OS.type == "unix") {
+#     # Workaround for https://github.com/jyypma/nloptr/issues/40
+#     install.dependencies("nloptr", github_deps=c("jyypma/nloptr"))
+# }
 install.dependencies("luminex", c("drc", "xtable", "Cairo", "plotrix"))

--- a/test/install-luminex-dependencies.R
+++ b/test/install-luminex-dependencies.R
@@ -20,4 +20,4 @@ source("install-util.R")
 #     # Workaround for https://github.com/jyypma/nloptr/issues/40
 #     install.dependencies("nloptr", github_deps=c("jyypma/nloptr"))
 # }
-install.dependencies("luminex", c("drc", "xtable", "Cairo", "plotrix"))
+install.dependencies("luminex", c("drc", "xtable", "Cairo", "plotrix", "nloptr"))


### PR DESCRIPTION
#### Rationale
[Issue 47089: Update TeamCity agents to use R v4.x](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47089)

#### Related Pull Requests
* https://github.com/LabKey/spy-school/pull/22

#### Changes
* Remove workaround for installing `nloptr` package
