### PR TITLE
Rlabkey changes for v2.10.0

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 2.9.1
-Date: 2022-12-15
+Version: 2.10.0
+Date: 2023-04-03
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,5 +1,7 @@
-Changes in 2.9.2 (??)
+Changes in 2.10.0
   o Update documentation to reflect removal of "apikey|" and "session|" prefixes from API keys and session keys
+  o Issue 47202: Options to reduce payload of getContainers.api response: includeChildWorkbooks, includeStandardProperties
+  o Note: only supported for LabKey Server v23.3
 
 Changes in 2.9.1
   o Freezer Manager API - add Primary Storage option to storage-related action documentation

--- a/Rlabkey/R/labkey.getFolders.R
+++ b/Rlabkey/R/labkey.getFolders.R
@@ -14,7 +14,8 @@
 # limitations under the License.
 ##
 
-labkey.getFolders <- function(baseUrl=NULL, folderPath, includeEffectivePermissions=TRUE, includeSubfolders=FALSE, depth=50)
+labkey.getFolders <- function(baseUrl=NULL, folderPath, includeEffectivePermissions=TRUE, includeSubfolders=FALSE, depth=50,
+    includeChildWorkbooks=TRUE, includeStandardProperties=TRUE)
 {
 	baseUrl=labkey.getBaseUrl(baseUrl)
 
@@ -27,9 +28,13 @@ labkey.getFolders <- function(baseUrl=NULL, folderPath, includeEffectivePermissi
 	## Formatting
 	if(includeSubfolders) {inclsf <- paste("1&depth=", depth, sep="")} else {inclsf <- "0"}
 	if(includeEffectivePermissions) {inclep <- "1"} else {inclep <- "0"}
+	if(includeChildWorkbooks) {inclcw <- "1"} else {inclcw <- "0"}
+	if(includeStandardProperties) {inclsp <- "1"} else {inclsp <- "0"}
 
 	## Construct url
-	myurl <- paste(baseUrl,"project",folderPath,"getContainers.view?","includeSubfolders=",inclsf,"&includeEffectivePermissions=",inclep, sep="")
+	myurl <- paste(baseUrl,"project",folderPath,"getContainers.view?","includeSubfolders=",inclsf,
+	    "&includeEffectivePermissions=",inclep,"&includeChildWorkbooks=",inclcw,"&includeStandardProperties=",inclsp,
+	    sep="")
 
 	## Execute via our standard GET function
 	mydata <- labkey.get(myurl);

--- a/Rlabkey/R/labkey.getFolders.R
+++ b/Rlabkey/R/labkey.getFolders.R
@@ -29,7 +29,13 @@ labkey.getFolders <- function(baseUrl=NULL, folderPath, includeEffectivePermissi
 	if(includeSubfolders) {inclsf <- paste("1&depth=", depth, sep="")} else {inclsf <- "0"}
 	if(includeEffectivePermissions) {inclep <- "1"} else {inclep <- "0"}
 	if(includeChildWorkbooks) {inclcw <- "1"} else {inclcw <- "0"}
-	if(includeStandardProperties) {inclsp <- "1"} else {inclsp <- "0"}
+
+	inclsp <- "0"
+	resultCols = c("name", "path", "id", "effectivePermissions")
+	if(includeStandardProperties) {
+	    inclsp <- "1"
+	    resultCols = c("name", "path", "id", "title", "type", "folderType", "effectivePermissions")
+	}
 
 	## Construct url
 	myurl <- paste(baseUrl,"project",folderPath,"getContainers.view?","includeSubfolders=",inclsf,
@@ -40,8 +46,6 @@ labkey.getFolders <- function(baseUrl=NULL, folderPath, includeEffectivePermissi
 	mydata <- labkey.get(myurl);
 
 	decode <- fromJSON(mydata, simplifyVector=FALSE, simplifyDataFrame=FALSE)
-
-	resultCols = c("name", "path", "id", "title", "type", "folderType", "effectivePermissions")
 
 	curfld <- decode
 	curfld$effectivePermissions = paste(curfld$effectivePermissions, collapse=",")
@@ -65,7 +69,11 @@ labkey.getFolders <- function(baseUrl=NULL, folderPath, includeEffectivePermissi
 	}
 
 	allpathsDF <- data.frame(allpaths, stringsAsFactors=FALSE)
-	colnames(allpathsDF) <- c("name", "folderPath", "id", "title", "type", "folderType", "effectivePermissions")
+	if(includeStandardProperties) {
+	    colnames(allpathsDF) <- c("name", "folderPath", "id", "title", "type", "folderType", "effectivePermissions")
+    } else {
+        colnames(allpathsDF) <- c("name", "folderPath", "id", "effectivePermissions")
+    }
 
 	return(allpathsDF)
 }

--- a/Rlabkey/R/labkey.security.R
+++ b/Rlabkey/R/labkey.security.R
@@ -16,9 +16,11 @@
 
 ## Returns information about the specified container, including the user's current permissions within that container.
 ##
-labkey.security.getContainers <- function(baseUrl=NULL, folderPath, includeEffectivePermissions=TRUE, includeSubfolders=FALSE, depth=50)
+labkey.security.getContainers <- function(baseUrl=NULL, folderPath, includeEffectivePermissions=TRUE, includeSubfolders=FALSE, depth=50,
+    includeChildWorkbooks=TRUE, includeStandardProperties=TRUE)
 {
-    results = labkey.getFolders(baseUrl, folderPath, includeEffectivePermissions, includeSubfolders, depth)
+    results = labkey.getFolders(baseUrl, folderPath, includeEffectivePermissions, includeSubfolders, depth,
+                                includeChildWorkbooks, includeStandardProperties)
     return (results)
 }
 

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 2.9.1\cr
-Date: \tab 2022-12-15\cr
+Version: \tab 2.10.0\cr
+Date: \tab 2023-04-03\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }

--- a/Rlabkey/man/labkey.getFolders.Rd
+++ b/Rlabkey/man/labkey.getFolders.Rd
@@ -7,7 +7,9 @@ Fetch a list of all folders accessible to the current user, starting from a give
 \usage{
 labkey.getFolders(baseUrl, folderPath,
         includeEffectivePermissions=TRUE,
-        includeSubfolders=FALSE, depth=50)
+        includeSubfolders=FALSE, depth=50,
+        includeChildWorkbooks=TRUE,
+        includeStandardProperties=TRUE)
 }
 \arguments{
   \item{baseUrl}{a string specifying the address of the LabKey Server, including the context root}
@@ -15,6 +17,8 @@ labkey.getFolders(baseUrl, folderPath,
   \item{includeEffectivePermissions}{If set to false, the effective permissions for this container resource will not be included. (defaults to TRUE).}
   \item{includeSubfolders}{whether the search for subfolders should recurse down the folder hierarchy}
   \item{depth}{maximum number of subfolder levels to show if includeSubfolders=TRUE}
+  \item{includeChildWorkbooks}{If true, include child containers of type workbook in the response (defaults to TRUE).}
+  \item{includeStandardProperties}{If true, include the standard container properties like title, formats, etc. in the response (defaults to TRUE).}
 }
 \details{
 Folders are a hierarchy of containers for data and files.   The are the place where permissions are set 

--- a/Rlabkey/man/labkey.security.getContainers.Rd
+++ b/Rlabkey/man/labkey.security.getContainers.Rd
@@ -7,8 +7,9 @@ If the includeSubfolders config option is set to true, it will also return infor
 the user is allowed to see.
 }
 \usage{
-labkey.security.getContainers(baseUrl=NULL, folderPath, includeEffectivePermissions=TRUE,
-    includeSubfolders=FALSE, depth=50)
+labkey.security.getContainers(baseUrl=NULL, folderPath,
+    includeEffectivePermissions=TRUE, includeSubfolders=FALSE, depth=50,
+    includeChildWorkbooks=TRUE, includeStandardProperties = TRUE)
 }
 \arguments{
   \item{baseUrl}{A string specifying the \code{baseUrl} for the labkey server.}
@@ -16,6 +17,8 @@ labkey.security.getContainers(baseUrl=NULL, folderPath, includeEffectivePermissi
   \item{includeEffectivePermissions}{If set to false, the effective permissions for this container resource will not be included (defaults to true).}
   \item{includeSubfolders}{If set to true, the entire branch of containers will be returned. If false, only the immediate children of the starting container will be returned (defaults to false).}
   \item{depth}{May be used to control the depth of recursion if includeSubfolders is set to true.}
+  \item{includeChildWorkbooks}{If true, include child containers of type workbook in the response (defaults to TRUE).}
+  \item{includeStandardProperties}{If true, include the standard container properties like title, formats, etc. in the response (defaults to TRUE).}
 }
 \details{
 This function returns information about the specified container, including the user's current permissions within that container.
@@ -41,7 +44,8 @@ library(Rlabkey)
 
 labkey.security.getContainers(
     baseUrl="http://labkey/", folderPath = "home",
-    includeEffectivePermissions = FALSE, includeSubfolders = TRUE, depth = 2
+    includeEffectivePermissions = FALSE, includeSubfolders = TRUE, depth = 2,
+    includeChildWorkbooks = FALSE, includeStandardProperties = FALSE
 )
 
 }


### PR DESCRIPTION
#### Rationale
- Issue [47434](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47434): Update documentation to reflect removal of "apikey|" and "session|" prefixes from API keys and session keys
- Issue [47202](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47202): Options to reduce payload of getContainers.api response: includeChildWorkbooks, includeStandardProperties

#### Related Pull Requests
* apiKey prefix - https://github.com/LabKey/platform/pull/4177
* getContainer API props - https://github.com/LabKey/platform/pull/4159
