### PR TITLE
Support Renaming Containers - part 2

### DIFF
--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,5 +1,6 @@
 Changes in 2.11.0
   o Add labkey.security.renameContainer
+  o Note: only supported for LabKey Server v23.5
 
 Changes in 2.10.0
   o Update documentation to reflect removal of "apikey|" and "session|" prefixes from API keys and session keys

--- a/Rlabkey/R/labkey.getQueryInfo.R
+++ b/Rlabkey/R/labkey.getQueryInfo.R
@@ -38,7 +38,7 @@ labkey.getDefaultViewDetails <- function(baseUrl=NULL, folderPath, schemaName, q
 	return(viewDetails)
 }
 
-## internal reoutine that handles all of these
+## internal routine that handles all of these
 getQueryInfo <- function(baseUrl=NULL, folderPath, schemaName, queryName, showDefaultView=FALSE, lookupKey=NULL)
 {
 	baseUrl=labkey.getBaseUrl(baseUrl)


### PR DESCRIPTION
#### Rationale
See related PR for rationale. This PR just adds the release note re: the supported LK version (missed from the previous merge).

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-r/pull/92

#### Changes
* update release note re: supported LK version
