### PR TITLE
Issue 48298: Align API Filter Operators

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 2.11.0
-Date: 2023-05-02
+Version: 2.12.0
+Date: 2023-08-18
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -10,6 +10,9 @@ Changes in 2.10.0
 Changes in 2.9.1
   o Freezer Manager API - add Primary Storage option to storage-related action documentation
 
+Changes in TBD
+  o Issue 48298: Add Lineage filter types to makeFilter
+
 Changes in 2.9.0
   o Add support for creating Freezer Manager freezer hierarchies
   o New labkey.storage NAMESPACE: labkey.storage.create, labkey.storage.update, labkey.storage.delete

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 2.12.0
+  o Issue 48298: Add Lineage filter types to makeFilter
+
 Changes in 2.11.0
   o Add labkey.security.renameContainer
   o Note: only supported for LabKey Server v23.5
@@ -9,9 +12,6 @@ Changes in 2.10.0
 
 Changes in 2.9.1
   o Freezer Manager API - add Primary Storage option to storage-related action documentation
-
-Changes in TBD
-  o Issue 48298: Add Lineage filter types to makeFilter
 
 Changes in 2.9.0
   o Add support for creating Freezer Manager freezer hierarchies

--- a/Rlabkey/R/makeFilter.R
+++ b/Rlabkey/R/makeFilter.R
@@ -118,9 +118,9 @@
 								#
 								# Lineage operators
 								#
-                                "EXP_CHILD_OF" = "exp:childof",
-                                "EXP_PARENT_OF" = "exp:parentof",
-                                "EXP_LINEAGE_OF" = "exp:lineageof",
+								"EXP_CHILD_OF" = "exp:childof",
+								"EXP_PARENT_OF" = "exp:parentof",
+								"EXP_LINEAGE_OF" = "exp:lineageof",
 								)
 
  				if(is.null(fop)==TRUE) stop ("Invalid operator name.")

--- a/Rlabkey/R/makeFilter.R
+++ b/Rlabkey/R/makeFilter.R
@@ -50,16 +50,16 @@
  								"DATE_GT"="dategt",
  								"DATE_GREATER_THAN"="dategt",
 
+ 								"LT"="lt",
+ 								"LESS_THAN"="lt",
+ 								"DATE_LT"="datelt",
+ 								"DATE_LESS_THAN"="datelt",
+
  								"GTE"="gte",
  								"GREATER_THAN_OR_EQUAL_TO"="gte",
  								"GREATER_THAN_OR_EQUAL"="gte",
  								"DATE_GTE"="dategte",
  								"DATE_GREATER_THAN_OR_EQUAL"="dategte",
-
- 								"LT"="lt",
- 								"LESS_THAN"="lt",
- 								"DATE_LT"="datelt",
- 								"DATE_LESS_THAN"="datelt",
 
  								"LTE"="lte",
  								"LESS_THAN_OR_EQUAL_TO"="lte",
@@ -110,10 +110,17 @@
 								"Q"="q",
 
 								#
-								# Ontology filters
+								# Ontology operators
 								#
 								"ONTOLOGY_IN_SUBTREE"="concept:insubtree",
 								"ONTOLOGY_NOT_IN_SUBTREE"="concept:notinsubtree",
+
+								#
+								# Lineage operators
+								#
+                                "EXP_CHILD_OF" = "exp:childof",
+                                "EXP_PARENT_OF" = "exp:parentof",
+                                "EXP_LINEAGE_OF" = "exp:lineageof",
 								)
 
  				if(is.null(fop)==TRUE) stop ("Invalid operator name.")

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 2.11.0\cr
-Date: \tab 2023-05-02\cr
+Version: \tab 2.12.0\cr
+Date: \tab 2023-08-18\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }

--- a/Rlabkey/man/makeFilter.Rd
+++ b/Rlabkey/man/makeFilter.Rd
@@ -53,6 +53,9 @@ NO_MV_INDICATOR\cr
 Q\cr
 ONTOLOGY_IN_SUBTREE\cr
 ONTOLOGY_NOT_IN_SUBTREE\cr
+EXP_CHILD_OF\cr
+EXP_PARENT_OF\cr
+EXP_LINEAGE_OF\cr
 
 When using the MISSING, NOT_MISSING, MV_INDICATOR, or NO_MV_INDICATOR operators, an empty string should be supplied as the value.
 See example below.


### PR DESCRIPTION
#### Rationale
In the process of adding lineage filter operators to the APIs, I noticed a handful of inconsistencies I'm resolving across the APIs. See related pull requests. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-python/pull/61
* https://github.com/LabKey/labkey-api-js/pull/157
* https://github.com/LabKey/labkey-api-r/pull/95
* https://github.com/LabKey/labkey-api-java/pull/60

#### Changes
* Update news
* Rearrange ordering of operator types to align with other APIs
* Add the following operators:
    * EXP_CHILD_OF
    * EXP_PARENT_OF
    * EXP_LINEAGE_OF
