### PR TITLE
Rlabkey v3.0.0

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 2.13.0
-Date: 2023-11-03
+Version: 3.0.0
+Date: 2023-11-06
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 2.12.0
-Date: 2023-08-18
+Version: 2.13.0
+Date: 2023-11-03
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NAMESPACE
+++ b/Rlabkey/NAMESPACE
@@ -4,7 +4,7 @@ export(labkey.selectRows, labkey.executeSql, makeFilter, labkey.insertRows, labk
 	labkey.getLookupDetails, labkey.makeRemotePath, getSession, getRows, getLookups, lsSchemas, lsFolders, lsProjects, labkey.saveBatch,
 	labkey.curlOptions, labkey.setCurlOptions, labkey.acceptSelfSignedCerts, labkey.setDefaults,
 	labkey.rstudio.initSession, labkey.rstudio.initRStudio, labkey.rstudio.initReport, labkey.rstudio.saveReport, labkey.rstudio.isInitialized,
-	labkey.transform.readRunPropertiesFile, labkey.transform.getRunPropertyValue, labkey.setDebugMode,
+	labkey.transform.readRunPropertiesFile, labkey.transform.getRunPropertyValue, labkey.setDebugMode, labkey.setWafEncoding,
 	labkey.webdav.get, labkey.webdav.put, labkey.webdav.delete, labkey.webdav.mkDir, labkey.webdav.mkDirs, labkey.webdav.pathExists, labkey.webdav.listDir, labkey.webdav.downloadFolder,
 	labkey.truncateTable)
 export("getSchema")

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,4 +1,4 @@
-Changes in 2.13.0
+Changes in 3.0.0
   o Issue 41677: Fix for domain get/save round tripping of domain indices (need to use list() for index columnNames)
   o Encode SQL parameters passed by labkey.executeSql to avoid rejection by web application firewalls
     o Earliest compatible LabKey Server version: 23.9.0

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 2.13.0
+  o Issue 41677: Fix for domain get/save round tripping of domain indices (need to use list() for index columnNames)
+
 Changes in 2.12.0
   o Issue 48298: Add Lineage filter types to makeFilter
 

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,5 +1,9 @@
 Changes in 2.13.0
   o Issue 41677: Fix for domain get/save round tripping of domain indices (need to use list() for index columnNames)
+  o Obfuscate SQL parameters passed by labkey.executeSql to avoid rejection by web application firewalls
+    o Earliest compatible LabKey Server version: 23.9.0
+    o This command is no longer compatible with earlier versions of LabKey Server (23.8.x and before) by default,
+        however, if targeting an older server, calling labkey.setWafEncoding(FALSE) will restore the previous behavior.
 
 Changes in 2.12.0
   o Issue 48298: Add Lineage filter types to makeFilter

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,6 +1,6 @@
 Changes in 2.13.0
   o Issue 41677: Fix for domain get/save round tripping of domain indices (need to use list() for index columnNames)
-  o Obfuscate SQL parameters passed by labkey.executeSql to avoid rejection by web application firewalls
+  o Encode SQL parameters passed by labkey.executeSql to avoid rejection by web application firewalls
     o Earliest compatible LabKey Server version: 23.9.0
     o This command is no longer compatible with earlier versions of LabKey Server (23.8.x and before) by default,
         however, if targeting an older server, calling labkey.setWafEncoding(FALSE) will restore the previous behavior.

--- a/Rlabkey/R/labkey.defaults.R
+++ b/Rlabkey/R/labkey.defaults.R
@@ -249,6 +249,19 @@ isDebug <- function()
     return (.lkdefaults$debug)
 }
 
+labkey.setWafEncoding <- function(wafEncode=TRUE)
+{
+    .lkdefaults$wafEncode = wafEncode;
+}
+
+isWafEncoding <- function()
+{
+    if (is.null(.lkdefaults$wafEncode)) {
+        return (TRUE)
+    }
+    return (.lkdefaults$wafEncode)
+}
+
 
 isRequestError <- function(response, status_code) 
 {
@@ -305,4 +318,19 @@ verboseOutput <- function(title, content)
         print(content)
         print(paste("*******************END ",title,"*********************", sep=""))
     }
+}
+
+# Obfuscates content that's often intercepted by web application firewalls that are scanning for likely
+# SQL or script injection. We have a handful of endpoints that intentionally accept SQL or script, so we
+# encode the text to avoid tripping alarms. It's a simple BASE64 encoding that obscures the content, and lets the
+# WAF scan for and reject malicious content on all other parameters. See Issue 48509.
+wafEncode <- function(value)
+{
+    if (!is.null(value) && is.character(value))
+    {
+        value <- URLencode(value)
+        value <- base64_enc(value)
+        value <- paste0("/*{{base64/x-www-form-urlencoded/wafText}}*/", value)
+    }
+    return (value)
 }

--- a/Rlabkey/R/labkey.defaults.R
+++ b/Rlabkey/R/labkey.defaults.R
@@ -328,9 +328,24 @@ wafEncode <- function(value)
 {
     if (!is.null(value) && is.character(value))
     {
-        value <- URLencode(value)
+        value <- encodeURIComponent(value)
         value <- base64_enc(value)
+        value <- gsub("\n", "", value) # jsonlite:base64_enc concats long strings with \n char
         value <- paste0("/*{{base64/x-www-form-urlencoded/wafText}}*/", value)
     }
+    return (value)
+}
+
+# URL Encode string.
+# NOTE: made to match JavaScript encodeURIComponent()
+encodeURIComponent <- function(value)
+{
+    value <- URLencode(value, reserved = TRUE)
+    # The following characters need to be decoded to match server side behavior: !  * ' ( )
+    value <- gsub("%21", "!", value)
+    value <- gsub("%2A", "*", value)
+    value <- gsub("%27", "'", value)
+    value <- gsub("%28", "(", value)
+    value <- gsub("%29", ")", value)
     return (value)
 }

--- a/Rlabkey/R/labkey.domain.R
+++ b/Rlabkey/R/labkey.domain.R
@@ -42,6 +42,11 @@ labkey.domain.get <- function(baseUrl=NULL, folderPath, schemaName, queryName)
     if (is.null(result$instructions)) result$instructions = NA
     if (is.null(result$domainKindName)) result$domainKindName = NA
 
+    # Issue 41677: domain indices come back with columnNames as character[] but need to be list for saveDomain
+    if (!is.null(result$indices)) {
+        result$indices$columnNames = lapply(result$indices$columnNames, as.list)
+    }
+
     return (result)
 }
 

--- a/Rlabkey/R/labkey.executeSql.R
+++ b/Rlabkey/R/labkey.executeSql.R
@@ -31,6 +31,9 @@ labkey.executeSql <- function(baseUrl=NULL, folderPath, schemaName, sql, maxRows
     ## Construct url
     myurl <- paste(baseUrl, "query", folderPath, "executeSql.api", sep="")
 
+    ## Apply wafEncode, if requested
+    if (isWafEncoding()) sql <- wafEncode(sql)
+
     ## Construct parameters
     params <- list(schemaName=schemaName, apiVersion=8.3, sql=sql)
     if(is.null(maxRows)==FALSE) {params <- c(params, list(maxRows=maxRows))}

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 2.13.0\cr
-Date: \tab 2023-11-03\cr
+Version: \tab 3.0.0\cr
+Date: \tab 2023-11-06\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 2.12.0\cr
-Date: \tab 2023-08-18\cr
+Version: \tab 2.13.0\cr
+Date: \tab 2023-11-03\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }

--- a/Rlabkey/man/labkey.getDefaultViewDetails.Rd
+++ b/Rlabkey/man/labkey.getDefaultViewDetails.Rd
@@ -24,10 +24,18 @@ The output field attributes of the default view are returned as a data frame.  S
 }
 \author{Peter Hussey, peter@labkey.com}
 \seealso{
-{Retrieve data:} \code{\link{labkey.selectRows}}, \code{\link{makeFilter}}, \code{\link{labkey.executeSql}} \cr
-{Modify data:  } \code{\link{labkey.updateRows}}, \code{\link{labkey.insertRows}}, \code{\link{labkey.importRows}}, \code{\link{labkey.deleteRows}}\cr
-{List available data: } \code{\link{labkey.getSchemas}}, \code{\link{labkey.getQueries}}, \code{\link{labkey.getQueryViews}}, 
-\code{\link{labkey.getQueryDetails}}, \code{\link{labkey.getLookupDetails}}
+\code{\link{labkey.selectRows}},
+\code{\link{makeFilter}},
+\code{\link{labkey.executeSql}},
+\code{\link{labkey.updateRows}},
+\code{\link{labkey.insertRows}},
+\code{\link{labkey.importRows}},
+\code{\link{labkey.deleteRows}},
+\code{\link{labkey.getSchemas}},
+\code{\link{labkey.getQueries}},
+\code{\link{labkey.getQueryViews}},
+\code{\link{labkey.getQueryDetails}},
+\code{\link{labkey.getLookupDetails}}
 }
 \examples{
 \dontrun{

--- a/Rlabkey/man/labkey.getLookupDetails.Rd
+++ b/Rlabkey/man/labkey.getLookupDetails.Rd
@@ -24,10 +24,18 @@ as detailed in \code{\link{labkey.getQueryDetails}}
 }
 \author{Peter Hussey, peter@labkey.com}
 \seealso{
-{Retrieve data:  } \code{\link{labkey.selectRows}},\code{\link{makeFilter}}, \code{\link{labkey.executeSql}} \cr
-{Modify data:  } \code{\link{labkey.updateRows}}, \code{\link{labkey.insertRows}}, \code{\link{labkey.importRows}}, \code{\link{labkey.deleteRows}}\cr
-{List available data: } \code{\link{labkey.getSchemas}}, \code{\link{labkey.getQueries}}, \code{\link{labkey.getQueryViews}}, 
-\code{\link{labkey.getQueryDetails}}, \code{\link{labkey.getDefaultViewDetails}}
+\code{\link{labkey.selectRows}},
+\code{\link{makeFilter}},
+\code{\link{labkey.executeSql}},
+\code{\link{labkey.updateRows}},
+\code{\link{labkey.insertRows}},
+\code{\link{labkey.importRows}},
+\code{\link{labkey.deleteRows}},
+\code{\link{labkey.getSchemas}},
+\code{\link{labkey.getQueries}},
+\code{\link{labkey.getQueryViews}},
+\code{\link{labkey.getQueryDetails}},
+\code{\link{labkey.getDefaultViewDetails}}
 }
 \examples{
 \dontrun{

--- a/Rlabkey/man/labkey.getQueries.Rd
+++ b/Rlabkey/man/labkey.getQueries.Rd
@@ -20,22 +20,29 @@ the data that is visible depends on the current user's permissions in a given fo
 Function arguments identify the location of the server and the folder path.
 }
 \value{
-The available queries are returned as a three-column data frame containing {one row for each field} for each query 
-in the specified schema.  The three columns are
-
-\code{queryName}{the name of the query object, repeated once for every field defined as output of the query.}  \cr
-\code{fieldName} {the name of a query output field} \cr 
-\code{caption}{the caption of the named field as shown in the column header of a data grid, also known as a label}\cr 
+The available queries are returned as a three-column data frame containing one row for each field for each query
+in the specified schema.  The three columns are \cr
+\item{queryName}{the name of the query object, repeated once for every field defined as output of the query.}  \cr
+\item{fieldName}{the name of a query output field} \cr
+\item{caption}{the caption of the named field as shown in the column header of a data grid, also known as a label} \cr
 
 }
 \references{http://www.omegahat.net/RCurl/,\cr
 https://www.labkey.org/project/home/begin.view}
 \author{Peter Hussey, peter@labkey.com}
 \seealso{
-{Retrieve data:  } \code{\link{labkey.selectRows}}, \code{\link{makeFilter}}, \code{\link{labkey.executeSql}} \cr
-{Modify data:  } \code{\link{labkey.updateRows}}, \code{\link{labkey.insertRows}}, \code{\link{labkey.importRows}}, \code{\link{labkey.deleteRows}}\cr
-{List available data: } \code{\link{labkey.getSchemas}}, \code{\link{labkey.getQueryViews}}, 
-\code{\link{labkey.getQueryDetails}}, \code{\link{labkey.getDefaultViewDetails}}, \code{\link{labkey.getLookupDetails}}
+\code{\link{labkey.selectRows}},
+\code{\link{makeFilter}},
+\code{\link{labkey.executeSql}},
+\code{\link{labkey.updateRows}},
+\code{\link{labkey.insertRows}},
+\code{\link{labkey.importRows}},
+\code{\link{labkey.deleteRows}},
+\code{\link{labkey.getSchemas}},
+\code{\link{labkey.getQueryViews}},
+\code{\link{labkey.getQueryDetails}},
+\code{\link{labkey.getDefaultViewDetails}},
+\code{\link{labkey.getLookupDetails}}
 
 }
 \examples{

--- a/Rlabkey/man/labkey.getQueryDetails.Rd
+++ b/Rlabkey/man/labkey.getQueryDetails.Rd
@@ -39,34 +39,41 @@ every record from the target queryName appears in the output whether or not ther
 
 }
 \value{
-The available schemas are returned as a data frame,
-
-\code{queryName} {the name of the query, repeated n times, where n is the number of output fields from the query} \cr
-\code{fieldName} {the fully qualified name of the field, relative to the specified queryName.  } \cr 
-\code{caption}  {a more readable label for the data field, appears as a column header in grids} \cr 
-\code{fieldKey} {the name part that identifies this field within its containing table, independent of its use as a lookup target.}\cr 
-\code{type} {a string specifying the field type, e.g. Text, Number, Date, Integer}\cr 
-\code{isNullable} {TRUE if the field can be left empty (null)} \cr
-\code{isKeyField} {TRUE if the field is part of the primary key} \cr
-\code{isAutoIncrement} {TRUE if the system will automatically assign a sequential integer in this on inserting a record}\cr 
-\code{isVersionField} {TRUE if the field issued to detect changes since last read} \cr
-\code{isHidden} {TRUE if the field is not displayed by default} \cr
-\code{isSelectable} {reserved for future use. }\cr
-\code{isUserEditable} {reserved for future use.}\cr
-\code{isReadOnly} {reserved for future use}\cr
-\code{isMvEnabled} {reserved for future use}\cr
-\code{lookupKeyField}  {for a field defined as a lookup the primary key column of the query referenced by the lookup field;  NA for non-lookup fields} \cr
-\code{lookupSchemaName} {the schema of the query referenced by the lookup field;  NA for non-lookup fields} \cr
-\code{lookupDisplayField} {the field from the query referenced by the lookup field that is shown by default in place of the lookup field;  NA for non-lookup fields} \cr 
-\code{lookupQueryName} {the query referenced by the lookup field;  NA for non-lookup fields.  A non-NA value indicates that you can use this field in a call to getLookups} \cr 
-\code{lookupIsPublic} {reserved for future use}\cr
+The available schemas are returned as a data frame:
+\item{queryName}{the name of the query, repeated n times, where n is the number of output fields from the query} \cr
+\item{fieldName}{the fully qualified name of the field, relative to the specified queryName.} \cr
+\item{caption}{a more readable label for the data field, appears as a column header in grids} \cr
+\item{fieldKey}{the name part that identifies this field within its containing table, independent of its use as a lookup target.} \cr
+\item{type}{a string specifying the field type, e.g. Text, Number, Date, Integer} \cr
+\item{isNullable}{TRUE if the field can be left empty (null)} \cr
+\item{isKeyField}{TRUE if the field is part of the primary key} \cr
+\item{isAutoIncrement}{TRUE if the system will automatically assign a sequential integer in this on inserting a record} \cr
+\item{isVersionField}{TRUE if the field issued to detect changes since last read} \cr
+\item{isHidden}{TRUE if the field is not displayed by default} \cr
+\item{isSelectable}{reserved for future use.} \cr
+\item{isUserEditable}{reserved for future use.} \cr
+\item{isReadOnly}{reserved for future use} \cr
+\item{isMvEnabled}{reserved for future use} \cr
+\item{lookupKeyField}{for a field defined as a lookup the primary key column of the query referenced by the lookup field;  NA for non-lookup fields} \cr
+\item{lookupSchemaName}{the schema of the query referenced by the lookup field;  NA for non-lookup fields} \cr
+\item{lookupDisplayField}{the field from the query referenced by the lookup field that is shown by default in place of the lookup field;  NA for non-lookup fields} \cr
+\item{lookupQueryName}{the query referenced by the lookup field;  NA for non-lookup fields.  A non-NA value indicates that you can use this field in a call to getLookups} \cr
+\item{lookupIsPublic}{reserved for future use} \cr
 }
 \author{Peter Hussey, peter@labkey.com}
 \seealso{
-{Retrieve data:  } \code{\link{labkey.selectRows}}, \code{\link{makeFilter}}, \code{\link{labkey.executeSql}} \cr
-{Modify data:  } \code{\link{labkey.updateRows}}, \code{\link{labkey.insertRows}}, \code{\link{labkey.importRows}}, \code{\link{labkey.deleteRows}} \cr
-{List available data: } \code{\link{labkey.getSchemas}}, \code{\link{labkey.getQueries}}, \code{\link{labkey.getQueryViews}}, 
-\code{\link{labkey.getDefaultViewDetails}}, \code{\link{labkey.getLookupDetails}}
+\code{\link{labkey.selectRows}},
+\code{\link{makeFilter}},
+\code{\link{labkey.executeSql}},
+\code{\link{labkey.updateRows}},
+\code{\link{labkey.insertRows}},
+\code{\link{labkey.importRows}},
+\code{\link{labkey.deleteRows}},
+\code{\link{labkey.getSchemas}},
+\code{\link{labkey.getQueries}},
+\code{\link{labkey.getQueryViews}},
+\code{\link{labkey.getDefaultViewDetails}},
+\code{\link{labkey.getLookupDetails}}
 }
 \examples{
 \dontrun{

--- a/Rlabkey/man/labkey.getQueryViews.Rd
+++ b/Rlabkey/man/labkey.getQueryViews.Rd
@@ -19,20 +19,27 @@ A named query view is created by using the \dQuote{Customize View} button option
 Use \code{getDefaultViewDetails} to get inforation about the default (unnamed) view.
 }
 \value{
-The available views for a query are returned as a three-column data frame, with one row per view output field.
-
-\code{viewName} {The name of the view, or NA for the default view.}\cr
-\code{fieldName} {The name of a field within the view, as defined in the query object to which the field belongs}\cr 
-\code{key} {The name of the field relative to the base query,  Use this value in the colSelect parameter of \code{labkey.selectRows()} .}\cr 
+The available views for a query are returned as a three-column data frame, with one row per view output field. \cr
+\item{viewName}{The name of the view, or NA for the default view.} \cr
+\item{fieldName}{The name of a field within the view, as defined in the query object to which the field belongs} \cr
+\item{key}{The name of the field relative to the base query,  Use this value in the colSelect parameter of \code{labkey.selectRows()}.} \cr
 
 }
 \references{https://www.labkey.org/Documentation/wiki-page.view?name=savingViews}
 \author{Peter Hussey, peter@labkey.com}
 \seealso{
-{Retrieve data:  } \code{\link{labkey.selectRows}},\code{\link{makeFilter}}, \code{\link{labkey.executeSql}} \cr
-{Modify data:  } \code{\link{labkey.updateRows}}, \code{\link{labkey.insertRows}}, \code{\link{labkey.importRows}}, \code{\link{labkey.deleteRows}} \cr
-{List available data: } \code{\link{labkey.getSchemas}}, \code{\link{labkey.getQueries}},
-\code{\link{labkey.getQueryDetails}},\code{\link{labkey.getDefaultViewDetails}},\code{\link{labkey.getLookupDetails}}
+\code{\link{labkey.selectRows}},
+\code{\link{makeFilter}},
+\code{\link{labkey.executeSql}},
+\code{\link{labkey.updateRows}},
+\code{\link{labkey.insertRows}},
+\code{\link{labkey.importRows}},
+\code{\link{labkey.deleteRows}},
+\code{\link{labkey.getSchemas}},
+\code{\link{labkey.getQueries}},
+\code{\link{labkey.getQueryDetails}},
+\code{\link{labkey.getDefaultViewDetails}},
+\code{\link{labkey.getLookupDetails}}
 
 
 }

--- a/Rlabkey/man/labkey.getSchemas.Rd
+++ b/Rlabkey/man/labkey.getSchemas.Rd
@@ -25,10 +25,17 @@ The available schemas are returned as a single-column data frame.
 https://www.labkey.org/project/home/begin.view}
 \author{Peter Hussey, peter@labkey.com}
 \seealso{
-{Retrieve data:  } \code{\link{labkey.selectRows}}, \code{\link{makeFilter}}, \code{\link{labkey.executeSql}} \cr
-{Modify data:  } \code{\link{labkey.updateRows}}, \code{\link{labkey.insertRows}}, \code{\link{labkey.importRows}}, \code{\link{labkey.deleteRows}}\cr
-{List available data: } \code{\link{labkey.getQueries}}, \code{\link{labkey.getQueryViews}}, 
-\code{\link{labkey.getQueryDetails}}, \code{\link{labkey.getDefaultViewDetails}},
+\code{\link{labkey.selectRows}},
+\code{\link{makeFilter}},
+\code{\link{labkey.executeSql}},
+\code{\link{labkey.updateRows}},
+\code{\link{labkey.insertRows}},
+\code{\link{labkey.importRows}},
+\code{\link{labkey.deleteRows}},
+\code{\link{labkey.getQueries}},
+\code{\link{labkey.getQueryViews}},
+\code{\link{labkey.getQueryDetails}},
+\code{\link{labkey.getDefaultViewDetails}},
 \code{\link{labkey.getLookupDetails}},
 
 }

--- a/Rlabkey/man/labkey.selectRows.Rd
+++ b/Rlabkey/man/labkey.selectRows.Rd
@@ -85,10 +85,18 @@ The requested data are returned in a data frame with stringsAsFactors set to FAL
 
 \author{Valerie Obenchain}
 \seealso{
-{Retrieve data:  } \code{\link{makeFilter}}, \code{\link{labkey.executeSql}} \cr
-{Modify data:  } \code{\link{labkey.updateRows}}, \code{\link{labkey.insertRows}}, \code{\link{labkey.importRows}}, \code{\link{labkey.deleteRows}}\cr
-{List available data: } \code{\link{labkey.getSchemas}}, \code{\link{labkey.getQueries}}, \code{\link{labkey.getQueryViews}},
-\code{\link{labkey.getQueryDetails}},\code{\link{labkey.getDefaultViewDetails}},\code{\link{labkey.getLookupDetails}},
+\code{\link{makeFilter}},
+\code{\link{labkey.executeSql}},
+\code{\link{labkey.updateRows}},
+\code{\link{labkey.insertRows}},
+\code{\link{labkey.importRows}},
+\code{\link{labkey.deleteRows}},
+\code{\link{labkey.getSchemas}},
+\code{\link{labkey.getQueries}},
+\code{\link{labkey.getQueryViews}},
+\code{\link{labkey.getQueryDetails}},
+\code{\link{labkey.getDefaultViewDetails}},
+\code{\link{labkey.getLookupDetails}}
 
 }
 \examples{

--- a/Rlabkey/man/labkey.setWafEncoding.Rd
+++ b/Rlabkey/man/labkey.setWafEncoding.Rd
@@ -10,7 +10,7 @@ server, pass FALSE to this method.
 labkey.setWafEncoding(wafEncode = TRUE)
 }
 \arguments{
-  \item{debug}{a boolean specifying if wafEncode mode is enabled or disabled}
+  \item{wafEncode}{a boolean specifying if wafEncode mode is enabled or disabled}
 }
 
 \author{Cory Nathe}

--- a/Rlabkey/man/labkey.setWafEncoding.Rd
+++ b/Rlabkey/man/labkey.setWafEncoding.Rd
@@ -1,0 +1,30 @@
+\name{labkey.setWafEncoding}
+\alias{labkey.setWafEncoding}
+\title{Helper function to enable/disable wafEncoding mode.}
+\description{
+By default, this command encodes the SQL parameter to allow it to pass through web application
+firewalls. This is compatible with LabKey Server v23.9.0 and above. If targeting an earlier
+server, pass FALSE to this method.
+}
+\usage{
+labkey.setWafEncoding(wafEncode = TRUE)
+}
+\arguments{
+  \item{debug}{a boolean specifying if wafEncode mode is enabled or disabled}
+}
+
+\author{Cory Nathe}
+\examples{
+\dontrun{
+
+library(Rlabkey)
+labkey.setWafEncoding(FALSE)
+labkey.executeSql(
+    baseUrl="http://localhost:8080/labkey",
+    folderPath="/home",
+    schemaName="core",
+    sql = "select * from containers")
+
+}
+}
+\keyword{IO}

--- a/Rlabkey/man/labkey.transform.readRunPropertiesFile.Rd
+++ b/Rlabkey/man/labkey.transform.readRunPropertiesFile.Rd
@@ -14,8 +14,7 @@ labkey.transform.readRunPropertiesFile(runInfoPath)
 
 \details{
 The most common scenario is that the assay transform script will get the run properties file path added
-into the running script as a replacement variable. To use that replacement variable for this helper function,
-you can pass in the runInfoPath parameter as "${runInfo}".\cr
+into the running script as a replacement variable.\cr
 }
 \examples{
 \dontrun{

--- a/Rlabkey/man/lsSchemas.Rd
+++ b/Rlabkey/man/lsSchemas.Rd
@@ -16,7 +16,7 @@ lsSchemas(session)
 \value{ A character array containing the available schema names
 }
 \author{Peter Hussey}
-\seealso{\code{\link{getSession}}, {\code{\link{lsFolders}}, \code{\link{lsProjects}}}
+\seealso{\code{\link{getSession}}, \code{\link{lsFolders}}, \code{\link{lsProjects}}}
 }
 \examples{
 \dontrun{

--- a/Rlabkey/man/lsSchemas.Rd
+++ b/Rlabkey/man/lsSchemas.Rd
@@ -16,7 +16,10 @@ lsSchemas(session)
 \value{ A character array containing the available schema names
 }
 \author{Peter Hussey}
-\seealso{\code{\link{getSession}}, \code{\link{lsFolders}}, \code{\link{lsProjects}}}
+\seealso{
+\code{\link{getSession}},
+\code{\link{lsFolders}},
+\code{\link{lsProjects}}
 }
 \examples{
 \dontrun{

--- a/Rlabkey/man/saveResults.Rd
+++ b/Rlabkey/man/saveResults.Rd
@@ -30,7 +30,7 @@ To see the save result on LabKey server, click on the "SimpleMeans" assay in the
 \references{
 https://www.labkey.org/project/home/begin.view}
 \author{Peter Hussey}
-\seealso{\code{\link{getSession}}, \code{\link{getSchema}}, \code{\link{getLookups}} \code{\link{getRows}}}
+\seealso{\code{\link{getSession}}, \code{\link{getSchema}}, \code{\link{getLookups}}, \code{\link{getRows}}}
 \examples{
 \dontrun{
 


### PR DESCRIPTION
#### Rationale
Issue [41677](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41677): Fix for domain get/save round tripping of domain indices (need to use list() for index columnNames)

Issue [48561](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=48561): Update R API to encode SQL parameters

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4699
* https://github.com/LabKey/platform/pull/4879

#### Changes
* add labkey.setWafEncoding() helper and use wafEncoding() in labkey.executeSql()
* labkey.domain.get to cast indices columnNames to list() instead of character array
