### PR TITLE
Replace `buildDir` with `layout.buildDirectory` and add an `excludedModules` property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 import org.labkey.gradle.task.InstallRPackage
 import org.labkey.gradle.util.GroupNames
+import org.labkey.gradle.util.BuildUtils
 
 buildscript {
     repositories {
@@ -43,7 +44,7 @@ buildscript {
     }
 }
 
-File buildOutputFile = new File(project.buildDir, "commands.out")
+File buildOutputFile = project.layout.buildDirectory.file("commands.out").get().getAsFile()
 String rLibsUserPath = InstallRPackage.getRLibsUserPath(project)
 String rExe = InstallRPackage.getRPath()
 
@@ -52,13 +53,13 @@ project.tasks.register("check") {
     Task task ->
         group GroupNames.VERIFICATION
         description "Run validation checks on the Rlabkey package"
-        task.outputs.dir project.file("${project.buildDir}/Rlabkey.Rcheck")
+        task.outputs.dir project.layout.buildDirectory.file("Rlabkey.Rcheck")
         task.outputs.dir project.file("Rlabkey/src-i386")
         task.outputs.dir project.file("Rlabkey/src-x64")
         task.outputs.files project.fileTree(dir: "Rlabkey/src", includes: ["*.o", "*.dll"])
 
         task.doLast {
-            File[] existingFiles = buildDir.listFiles(new FilenameFilter() {
+            File[] existingFiles = BuildUtils.getBuildDir(project).listFiles(new FilenameFilter() {
                 @Override
                 boolean accept(File dir, String name) {
                     return name.endsWith(".tar.gz");
@@ -69,7 +70,7 @@ project.tasks.register("check") {
                         executable: rExe,
                         output: buildOutputFile,
                         append: true,
-                        dir: project.buildDir,
+                        dir: BuildUtils.getBuildDir(project),
                         logError: true
                 )
                         {
@@ -86,13 +87,13 @@ project.tasks.register("build") {
         task.group GroupNames.BUILD
         task.description "Build the Rlabkey package that can be installed and tested in R. Builds binary package on windows, source only on unix"
         task.inputs.files project.fileTree(dir: "Rlabkey", excludes: ["src-i386", "src-x64"]).files
-        task.outputs.dir project.buildDir
+        task.outputs.dir project.layout.buildDirectory
         task.doFirst(
                 {
-                    project.buildDir.mkdirs()
+                    BuildUtils.getBuildDir(project).mkdirs()
                     project.ant.exec(
                             executable: rExe,
-                            dir: project.buildDir,
+                            dir: BuildUtils.getBuildDir(project),
                             output: buildOutputFile,
                             append: true,
                             logError: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 artifactory_contextUrl=https://labkey.jfrog.io/artifactory
-gradlePluginsVersion=1.41.0
+gradlePluginsVersion=1.43.0-buildDirBeGone-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 artifactory_contextUrl=https://labkey.jfrog.io/artifactory
-gradlePluginsVersion=1.43.0-buildDirBeGone-SNAPSHOT
+gradlePluginsVersion=1.43.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -21,10 +21,13 @@ project.tasks.register("installRLabKey", CopyAndInstallRPackage) {
     CopyAndInstallRPackage task ->
         task.group = GroupNames.DEPLOY
         task.description = "Install RLabKey and its dependencies"
-        task.packageLocation = parent.layout.buildDirectory
+        task.packageLocation = parent.layout.buildDirectory.get().asFile
         task.packageNames = ["Rlabkey"]
         task.installScript = "install-rlabkey-dependencies.R"
-        task.dependsOn(rootProject.tasks.getByName("build"))
+        try {
+            task.dependsOn(rootProject.tasks.named("build"))
+        }
+        catch (UnknownTaskException ignored) {}
         task.doFirst {
             project.copy {
                 CopySpec copy ->

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -21,7 +21,7 @@ project.tasks.register("installRLabKey", CopyAndInstallRPackage) {
     CopyAndInstallRPackage task ->
         task.group = GroupNames.DEPLOY
         task.description = "Install RLabKey and its dependencies"
-        task.packageLocation = parent.buildDir
+        task.packageLocation = parent.layout.buildDirectory
         task.packageNames = ["Rlabkey"]
         task.installScript = "install-rlabkey-dependencies.R"
         task.dependsOn(rootProject.tasks.getByName("build"))


### PR DESCRIPTION
#### Rationale
In Gradle 8.3, the use of `project.buildDir` was [deprecated](https://docs.gradle.org/current/userguide/upgrading_version_8.html#project_builddir) in favor of `project.layout.buildDirectory`.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/185

#### Changes
* Update gradlePluginsVersion
* replace usages of `buildDir` with  `layout.buildDirectory` or corresponding utility
* Update to Gradle 8.4
