### PR TITLE
Add labkey.moveRows

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 3.1.0
-Date: 2023-12-04
+Version: 3.2.0
+Date: 2024-01-02
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NAMESPACE
+++ b/Rlabkey/NAMESPACE
@@ -6,7 +6,7 @@ export(labkey.selectRows, labkey.executeSql, makeFilter, labkey.insertRows, labk
 	labkey.rstudio.initSession, labkey.rstudio.initRStudio, labkey.rstudio.initReport, labkey.rstudio.saveReport, labkey.rstudio.isInitialized,
 	labkey.transform.readRunPropertiesFile, labkey.transform.getRunPropertyValue, labkey.setDebugMode, labkey.setWafEncoding,
 	labkey.webdav.get, labkey.webdav.put, labkey.webdav.delete, labkey.webdav.mkDir, labkey.webdav.mkDirs, labkey.webdav.pathExists, labkey.webdav.listDir, labkey.webdav.downloadFolder,
-	labkey.truncateTable)
+	labkey.truncateTable, labkey.moveRows)
 export("getSchema")
 export("getFolderPath")
 export("saveResults")

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,7 @@
+Changes in 3.2.0
+  o Add labkey.moveRows
+  o Note: only supported for LabKey Server v24.1
+
 Changes in 3.1.0
   o Issue 48490: Add options parameter to labkey.insertRows, labkey.updateRows, labkey.deleteRows to support
         specifying the "auditBehavior" and "auditUserComment" properties for the action

--- a/Rlabkey/R/labkey.deleteRows.R
+++ b/Rlabkey/R/labkey.deleteRows.R
@@ -41,7 +41,7 @@ labkey.deleteRows <- function(baseUrl=NULL, folderPath, schemaName, queryName, t
     if (!missing(options))
         params <- c(params, options)
 
-    pbody <- jsonEncodeRowsAndParams(toDelete, params, FALSE)
+    pbody <- jsonEncodeRowsAndParams(toDelete, params, NULL)
 
     myurl <- paste(baseUrl, "query", folderPath, "deleteRows.api", sep="")
 

--- a/Rlabkey/R/labkey.deleteRows.R
+++ b/Rlabkey/R/labkey.deleteRows.R
@@ -34,8 +34,6 @@ labkey.deleteRows <- function(baseUrl=NULL, folderPath, schemaName, queryName, t
 
     ## URL encode folder path, JSON encode post body (if not already encoded)
     toDelete <- convertFactorsToStrings(toDelete);
-    nrows <- nrow(toDelete)
-    ncols <- ncol(toDelete)
 
     params <- list(schemaName=schemaName, queryName=queryName, apiVersion=8.3)
     if (!missing(provenanceParams))
@@ -43,18 +41,7 @@ labkey.deleteRows <- function(baseUrl=NULL, folderPath, schemaName, queryName, t
     if (!missing(options))
         params <- c(params, options)
 
-    p1 <- toJSON(params, auto_unbox=TRUE)
-    cnames <- colnames(toDelete)
-    p3 <- NULL
-    for(j in 1:nrows)
-    {
-        cvalues <- as.list(toDelete[j,])
-        names(cvalues) <- cnames
-        p2 <- toJSON(cvalues, auto_unbox=TRUE)
-        p3 <- c(p3, p2)
-    }
-    p3 <- paste(p3, collapse=",")
-    pbody <- paste(substr(p1, 1, nchar(p1) - 1),', \"rows\":[',p3,"] }",sep="")
+    pbody <- jsonEncodeRowsAndParams(toDelete, params, FALSE)
 
     myurl <- paste(baseUrl, "query", folderPath, "deleteRows.api", sep="")
 

--- a/Rlabkey/R/labkey.importRows.R
+++ b/Rlabkey/R/labkey.importRows.R
@@ -32,21 +32,8 @@ labkey.importRows <- function(baseUrl=NULL, folderPath, schemaName, queryName, t
 
     ## URL encode folder path, JSON encode post body (if not already encoded)
     toImport <- convertFactorsToStrings(toImport);
-    nrows <- nrow(toImport)
-    ncols <- ncol(toImport)
-    p1 <- toJSON(list(schemaName=schemaName, queryName=queryName, apiVersion=8.3), auto_unbox=TRUE)
-    cnames <- colnames(toImport)
-    p3 <- NULL
-    for(j in 1:nrows)
-    {
-        cvalues <- as.list(toImport[j,])
-        names(cvalues) <- cnames
-        cvalues[is.na(cvalues)] = na
-        p2 <- toJSON(cvalues, auto_unbox=TRUE)
-        p3 <- c(p3, p2)
-    }
-    p3 <- paste(p3, collapse=",")
-    pbody <- paste(substr(p1,1,nchar(p1)-1),', \"rows\":[',p3,"] }", sep="")
+    params <- list(schemaName=schemaName, queryName=queryName, apiVersion=8.3)
+    pbody <- jsonEncodeRowsAndParams(toImport, params, TRUE)
 
     myurl <- paste(baseUrl, "query", folderPath, "importRows.api", sep="")
 

--- a/Rlabkey/R/labkey.importRows.R
+++ b/Rlabkey/R/labkey.importRows.R
@@ -33,7 +33,7 @@ labkey.importRows <- function(baseUrl=NULL, folderPath, schemaName, queryName, t
     ## URL encode folder path, JSON encode post body (if not already encoded)
     toImport <- convertFactorsToStrings(toImport);
     params <- list(schemaName=schemaName, queryName=queryName, apiVersion=8.3)
-    pbody <- jsonEncodeRowsAndParams(toImport, params, TRUE)
+    pbody <- jsonEncodeRowsAndParams(toImport, params, na)
 
     myurl <- paste(baseUrl, "query", folderPath, "importRows.api", sep="")
 

--- a/Rlabkey/R/labkey.insertRows.R
+++ b/Rlabkey/R/labkey.insertRows.R
@@ -34,8 +34,6 @@ labkey.insertRows <- function(baseUrl=NULL, folderPath, schemaName, queryName, t
 
     ## URL encode folder path, JSON encode post body (if not already encoded)
     toInsert <- convertFactorsToStrings(toInsert);
-    nrows <- nrow(toInsert)
-    ncols <- ncol(toInsert)
 
     params <- list(schemaName=schemaName, queryName=queryName, apiVersion=8.3)
     if (!missing(provenanceParams))
@@ -43,19 +41,7 @@ labkey.insertRows <- function(baseUrl=NULL, folderPath, schemaName, queryName, t
     if (!missing(options))
         params <- c(params, options)
 
-    p1 <- toJSON(params, auto_unbox=TRUE)
-    cnames <- colnames(toInsert)
-    p3 <- NULL
-    for(j in 1:nrows)
-    {
-        cvalues <- as.list(toInsert[j,])
-        names(cvalues) <- cnames
-        cvalues[is.na(cvalues)] = na
-        p2 <- toJSON(cvalues, auto_unbox=TRUE)
-        p3 <- c(p3, p2)
-    }
-    p3 <- paste(p3, collapse=",")
-    pbody <- paste(substr(p1, 1, nchar(p1)-1), ', \"rows\":[' ,p3, "] }", sep="")
+    pbody <- jsonEncodeRowsAndParams(toInsert, params, TRUE)
 
     myurl <- paste(baseUrl, "query", folderPath, "insertRows.api", sep="")
 

--- a/Rlabkey/R/labkey.insertRows.R
+++ b/Rlabkey/R/labkey.insertRows.R
@@ -41,7 +41,7 @@ labkey.insertRows <- function(baseUrl=NULL, folderPath, schemaName, queryName, t
     if (!missing(options))
         params <- c(params, options)
 
-    pbody <- jsonEncodeRowsAndParams(toInsert, params, TRUE)
+    pbody <- jsonEncodeRowsAndParams(toInsert, params, na)
 
     myurl <- paste(baseUrl, "query", folderPath, "insertRows.api", sep="")
 

--- a/Rlabkey/R/labkey.moveRows.R
+++ b/Rlabkey/R/labkey.moveRows.R
@@ -37,7 +37,7 @@ labkey.moveRows <- function(baseUrl=NULL, folderPath, targetFolderPath, schemaNa
     if (!missing(options))
         params <- c(params, options)
 
-    pbody <- jsonEncodeRowsAndParams(toMove, params, FALSE)
+    pbody <- jsonEncodeRowsAndParams(toMove, params, NULL)
 
     myurl <- paste(baseUrl, "query", folderPath, "moveRows.api", sep="")
 

--- a/Rlabkey/R/labkey.moveRows.R
+++ b/Rlabkey/R/labkey.moveRows.R
@@ -1,0 +1,50 @@
+##
+#  Copyright (c) 2010-2018 LabKey Corporation
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+##
+
+labkey.moveRows <- function(baseUrl=NULL, folderPath, targetFolderPath, schemaName, queryName, toMove, options = NULL)
+{  
+    baseUrl=labkey.getBaseUrl(baseUrl)
+
+    ## Validate required parameters
+    if (missing(folderPath)) stop (paste("A value must be specified for folderPath."))
+    if (missing(targetFolderPath)) stop (paste("A value must be specified for targetFolderPath."))
+    if (missing(schemaName)) stop (paste("A value must be specified for schemaName."))
+    if (missing(queryName)) stop (paste("A value must be specified for queryName."))
+    if (missing(toMove)) stop (paste("A value must be specified for toMove."))
+    if (!missing(options) & !is.list(options))
+        stop (paste("The options parameter must be a list data structure."))
+
+    ## normalize the folder path
+    folderPath <- encodeFolderPath(folderPath)
+
+    ## URL encode folder path, JSON encode post body (if not already encoded)
+    toMove <- convertFactorsToStrings(toMove);
+
+    params <- list(targetContainerPath=targetFolderPath, schemaName=schemaName, queryName=queryName, apiVersion=8.3)
+    if (!missing(options))
+        params <- c(params, options)
+
+    pbody <- jsonEncodeRowsAndParams(toMove, params, FALSE)
+
+    myurl <- paste(baseUrl, "query", folderPath, "moveRows.api", sep="")
+
+    ## Execute via our standard POST function
+    mydata <- labkey.post(myurl, pbody)
+    newdata <- fromJSON(mydata, simplifyVector=FALSE, simplifyDataFrame=FALSE)
+
+    return(newdata)
+}
+                                                              

--- a/Rlabkey/R/labkey.updateRows.R
+++ b/Rlabkey/R/labkey.updateRows.R
@@ -34,8 +34,6 @@ labkey.updateRows <- function(baseUrl=NULL, folderPath, schemaName, queryName, t
 
     ## URL encode folder path, JSON encode post body (if not already encoded)
     toUpdate <- convertFactorsToStrings(toUpdate);
-    nrows <- nrow(toUpdate)
-    ncols <- ncol(toUpdate)
 
     params <- list(schemaName=schemaName, queryName=queryName, apiVersion=8.3)
     if (!missing(provenanceParams))
@@ -43,18 +41,7 @@ labkey.updateRows <- function(baseUrl=NULL, folderPath, schemaName, queryName, t
     if (!missing(options))
         params <- c(params, options)
 
-    p1 <- toJSON(params, auto_unbox=TRUE)
-    cnames <- colnames(toUpdate)
-    p3 <- NULL
-    for(j in 1:nrows)
-    {
-        cvalues <- as.list(toUpdate[j,])
-        names(cvalues) <- cnames
-        p2 <- toJSON(cvalues, auto_unbox=TRUE)
-        p3 <- c(p3, p2)
-    }
-    p3 <- paste(p3, collapse=",")
-    pbody <- paste(substr(p1,1,nchar(p1)-1), ', \"rows\":[', p3 ,"] }", sep="")
+    pbody <- jsonEncodeRowsAndParams(toUpdate, params, FALSE)
 
     myurl <- paste(baseUrl, "query", folderPath, "updateRows.api", sep="")
 

--- a/Rlabkey/R/labkey.updateRows.R
+++ b/Rlabkey/R/labkey.updateRows.R
@@ -41,7 +41,7 @@ labkey.updateRows <- function(baseUrl=NULL, folderPath, schemaName, queryName, t
     if (!missing(options))
         params <- c(params, options)
 
-    pbody <- jsonEncodeRowsAndParams(toUpdate, params, FALSE)
+    pbody <- jsonEncodeRowsAndParams(toUpdate, params, NULL)
 
     myurl <- paste(baseUrl, "query", folderPath, "updateRows.api", sep="")
 

--- a/Rlabkey/R/makeDF.R
+++ b/Rlabkey/R/makeDF.R
@@ -232,3 +232,25 @@ convertFactorsToStrings <- function(df)
     df[factors] <- lapply(df[factors], as.character)
     return(df);
 }
+
+# JSON encode "rows" post body
+jsonEncodeRowsAndParams <- function(rows, params, checkIsNa=FALSE)
+{
+    nrows <- nrow(rows)
+    p1 <- toJSON(params, auto_unbox=TRUE)
+    cnames <- colnames(rows)
+    p3 <- NULL
+    for(j in 1:nrows)
+    {
+        cvalues <- as.list(rows[j,])
+        names(cvalues) <- cnames
+        if (checkIsNa) {
+            cvalues[is.na(cvalues)] = na
+        }
+        p2 <- toJSON(cvalues, auto_unbox=TRUE)
+        p3 <- c(p3, p2)
+    }
+    p3 <- paste(p3, collapse=",")
+    pbody <- paste(substr(p1, 1, nchar(p1) - 1),', \"rows\":[',p3,"] }",sep="")
+    return(pbody)
+}

--- a/Rlabkey/R/makeDF.R
+++ b/Rlabkey/R/makeDF.R
@@ -234,7 +234,7 @@ convertFactorsToStrings <- function(df)
 }
 
 # JSON encode "rows" post body
-jsonEncodeRowsAndParams <- function(rows, params, checkIsNa=FALSE)
+jsonEncodeRowsAndParams <- function(rows, params, na=NULL)
 {
     nrows <- nrow(rows)
     p1 <- toJSON(params, auto_unbox=TRUE)
@@ -244,7 +244,7 @@ jsonEncodeRowsAndParams <- function(rows, params, checkIsNa=FALSE)
     {
         cvalues <- as.list(rows[j,])
         names(cvalues) <- cnames
-        if (checkIsNa) {
+        if (!is.null(na)) {
             cvalues[is.na(cvalues)] = na
         }
         p2 <- toJSON(cvalues, auto_unbox=TRUE)

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 3.1.0\cr
-Date: \tab 2023-12-04\cr
+Version: \tab 3.2.0\cr
+Date: \tab 2024-01-02\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }

--- a/Rlabkey/man/labkey.deleteRows.Rd
+++ b/Rlabkey/man/labkey.deleteRows.Rd
@@ -53,7 +53,7 @@ deleted.
 \seealso{
 \code{\link{labkey.selectRows}}, \code{\link{labkey.executeSql}}, \code{\link{makeFilter}}, 
 \code{\link{labkey.insertRows}}, \code{\link{labkey.importRows}}, \cr
-\code{\link{labkey.updateRows}},
+\code{\link{labkey.updateRows}}, \code{\link{labkey.moveRows}}, \cr
 \code{\link{labkey.provenance.createProvenanceParams}},
 \code{\link{labkey.provenance.startRecording}},
 \code{\link{labkey.provenance.addRecordingStep}},

--- a/Rlabkey/man/labkey.insertRows.Rd
+++ b/Rlabkey/man/labkey.insertRows.Rd
@@ -49,7 +49,7 @@ inserted.
 \seealso{
 \code{\link{labkey.selectRows}}, \code{\link{labkey.executeSql}}, \code{\link{makeFilter}}, 
 \code{\link{labkey.importRows}}, \code{\link{labkey.updateRows}}, \cr
-\code{\link{labkey.deleteRows}},
+\code{\link{labkey.deleteRows}}, \code{\link{labkey.moveRows}}, \cr
 \code{\link{labkey.query.import}},
 \code{\link{labkey.provenance.createProvenanceParams}},
 \code{\link{labkey.provenance.startRecording}},

--- a/Rlabkey/man/labkey.moveRows.Rd
+++ b/Rlabkey/man/labkey.moveRows.Rd
@@ -1,8 +1,8 @@
 \name{labkey.moveRows}
 \alias{labkey.moveRows}
-\title{Delete rows of data from a LabKey database}
+\title{Move rows of data from a LabKey database}
 \description{
-Specify rows of data to be deleted from the LabKey Server
+Specify rows of data to be moved from the LabKey Server
 }
 \usage{
 labkey.moveRows(baseUrl, folderPath, targetFolderPath,

--- a/Rlabkey/man/labkey.moveRows.Rd
+++ b/Rlabkey/man/labkey.moveRows.Rd
@@ -1,0 +1,74 @@
+\name{labkey.moveRows}
+\alias{labkey.moveRows}
+\title{Delete rows of data from a LabKey database}
+\description{
+Specify rows of data to be deleted from the LabKey Server
+}
+\usage{
+labkey.moveRows(baseUrl, folderPath, targetFolderPath,
+    schemaName, queryName, toMove, options=NULL)
+}
+\arguments{
+  \item{baseUrl}{a string specifying the \code{baseUrl}for LabKey server}
+  \item{folderPath}{a string specifying the \code{folderPath} for the source container of the rows}
+  \item{targetFolderPath}{a string specifying the \code{targetFolderPath} where the rows should be moved}
+  \item{schemaName}{a string specifying the \code{schemaName} for the query}
+  \item{queryName}{a string specifying the \code{queryName}}
+  \item{toMove}{a data frame containing a single column of data containing the data identifiers of the rows to be moved}
+  \item{options}{(optional) a list containing options specific to the move action of the query}
+}
+\details{
+Move a set of rows from the source container to a target container for a table. Note that this is not implemented for
+all tables.
+
+The list of valid options for each query will vary, but some common examples include:
+    \itemize{
+        \item{ \code{auditBehavior (string)} : Can be used to override the audit behavior for the table the query is acting on.
+            The set of types include: NONE, SUMMARY, and DETAILED.}
+        \item{ \code{auditUserComment (string)} : Can be used to provide a comment from the user that will be attached to
+            certain detailed audit log records.}
+    }
+}
+\value{
+A list is returned with named categories of \bold{command}, \bold{rowsAffected}, \bold{schemaName}, \bold{queryName},
+\bold{containerPath} and \bold{updateCounts}.
+The \bold{containerPath} will be the target container path where the rows were moved.
+The \bold{rowsAffected} property indicates the number of rows affected by the API action. This will typically be the same
+number as passed in the request.
+The \bold{updateCounts} property is a list of the number of items moved for various related items.
+}
+\author{Cory Nathe}
+\seealso{
+\code{\link{labkey.deleteRows}}, \cr
+\code{\link{labkey.importRows}}, \cr
+\code{\link{labkey.importRows}}, \cr
+\code{\link{labkey.updateRows}},
+}
+
+\examples{
+\dontrun{
+
+## Note that users must have the necessary permissions in the LabKey Server
+## to be able to modify data through the use of these functions
+# library(Rlabkey)
+
+newrow <- data.frame(
+	DisplayFld="Inserted from R"
+	, IntFld= 98
+	, DateTimeFld = "03/01/2010"
+	, stringsAsFactors=FALSE)
+
+insertedRow <- labkey.insertRows("http://localhost:8080/labkey",
+    folderPath="/apisamples", schemaName="samples",
+    queryName="Blood", toInsert=newrow)
+newRowId <- insertedRow$rows[[1]]$RowId
+
+result <- labkey.moveRows(baseUrl="http://localhost:8080/labkey",
+    folderPath="/apisamples", folderPath="/apisamples/subA", schemaName="samples",
+    queryName="Blood",  toMove=data.frame(RowId=c(newRowId)),
+    options = list(auditUserComment="testing comment from API call", auditBehavior="DETAILED"))
+result
+
+}
+}
+\keyword{IO}

--- a/Rlabkey/man/labkey.updateRows.Rd
+++ b/Rlabkey/man/labkey.updateRows.Rd
@@ -46,7 +46,7 @@ updated.
 \seealso{
 \code{\link{labkey.selectRows}}, \code{\link{labkey.executeSql}}, \code{\link{makeFilter}}, 
 \code{\link{labkey.insertRows}}, \code{\link{labkey.importRows}}, \cr
-\code{\link{labkey.deleteRows}},
+\code{\link{labkey.deleteRows}}, \code{\link{labkey.moveRows}}, \cr
 \code{\link{labkey.query.import}},
 \code{\link{labkey.provenance.createProvenanceParams}},
 \code{\link{labkey.provenance.startRecording}},


### PR DESCRIPTION
#### Rationale
Related PR added a query-moveRows.api to the QueryController so that we could consolidate the various move entities actions to a single action. This PR adds labkey.moveRows() to the Rlabkey package.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/167
- https://github.com/LabKey/labkey-api-python/pull/73

#### Changes
- factor out jsonEncodeRowsAndParams to be used in labkey.deleteRows.R, labkey.importRows.R, labkey.insertRows.R, and labkey.updateRows.R
- add new labkey.moveRows.R and related man doc page
