### PR TITLE
labkey.setDefaults to clear httr session cookies

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 3.2.0
-Date: 2024-01-02
+Version: 3.2.1
+Date: 2024-04-04
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 3.2.1
+  o labkey.setDefaults to clear httr session cookies
+
 Changes in 3.2.0
   o Add labkey.moveRows
   o Note: only supported for LabKey Server v24.1

--- a/Rlabkey/R/labkey.defaults.R
+++ b/Rlabkey/R/labkey.defaults.R
@@ -21,6 +21,11 @@
 # the apiKey will be given preference in labkey.getRequestOptions().
 labkey.setDefaults <- function(apiKey="", baseUrl="", email="", password="")
 {
+    # with any reset of the defaults, clear the httr session cookies (https://stackoverflow.com/questions/39979393/how-to-remove-cookies-preserved-by-httrget)
+    if (!is.null(.lkdefaults$baseUrl)) {
+        handle_reset(.lkdefaults$baseUrl)
+    }
+
     if (baseUrl != "")
         .lkdefaults$baseUrl = baseUrl;
 

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 3.2.0\cr
-Date: \tab 2024-01-02\cr
+Version: \tab 3.2.1\cr
+Date: \tab 2024-04-04\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }


### PR DESCRIPTION
#### Rationale
When an API call is made the httr package uses cookies to stash some session info. If a call is made to labkey.setDefaults() to change the apiKey or baseUrl or other prop, those cookies would no longer be valid but will continue to be used for the next api call made in the Rlabkey package. This PR makes a call to handle_reset() when labkey.setDefaults() is made to clear that session info.

#### Changes
- labkey.setDefaults to clear httr session cookies
