### PR TITLE
Issue 50592: labkey.setDefaults to also clear the CSRF token cache when clearing the httr session cookies

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 3.2.1
-Date: 2024-04-04
+Version: 3.2.2
+Date: 2024-06-06
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,4 +1,4 @@
-Changes in 3.2.1
+Changes in 3.2.2
   o Issue 50592: labkey.setDefaults to also clear the CSRF token cache when clearing the httr session cookies
 
 Changes in 3.2.1

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,4 +1,7 @@
 Changes in 3.2.1
+  o Issue 50592: labkey.setDefaults to also clear the CSRF token cache when clearing the httr session cookies
+
+Changes in 3.2.1
   o labkey.setDefaults to clear httr session cookies
 
 Changes in 3.2.0

--- a/Rlabkey/R/labkey.defaults.R
+++ b/Rlabkey/R/labkey.defaults.R
@@ -24,6 +24,10 @@ labkey.setDefaults <- function(apiKey="", baseUrl="", email="", password="")
     # with any reset of the defaults, clear the httr session cookies (https://stackoverflow.com/questions/39979393/how-to-remove-cookies-preserved-by-httrget)
     if (!is.null(.lkdefaults$baseUrl)) {
         handle_reset(.lkdefaults$baseUrl)
+
+        # Issue 50592: clear the CSRF token cache as well
+        urlBase = labkey.getBaseUrl()
+        .lkcsrf[[urlBase]] = NULL
     }
 
     if (baseUrl != "")

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 3.2.1\cr
-Date: \tab 2024-04-04\cr
+Version: \tab 3.2.2\cr
+Date: \tab 2024-06-06\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50592

The related PR included a fix so that when labkey.setDefaults() is called we clear the httr package cookies that stash session info. Another related item that we stash and need to clear is the CSRF token. This PR fixes that issue to clear that as well.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-r/pull/103

#### Changes
- labkey.setDefaults to also clear the CSRF token cache 
