### PR TITLE
Remove JSON plate metadata support

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 3.2.2
-Date: 2024-06-06
+Version: 3.2.3
+Date: 2024-06-25
 Title: Data Exchange Between R and 'LabKey' Server
 Author: Peter Hussey 
 Maintainer: Cory Nathe <cnathe@labkey.com>

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 3.2.3
+  o Remove deprecated support for JSON based assay plate metadata
+
 Changes in 3.2.2
   o Issue 50592: labkey.setDefaults to also clear the CSRF token cache when clearing the httr session cookies
 

--- a/Rlabkey/R/labkey.experiment.R
+++ b/Rlabkey/R/labkey.experiment.R
@@ -66,7 +66,7 @@ labkey.experiment.createMaterial <- function(config, sampleSetId = NULL, sampleS
 
 ## Create an ExpRun object
 ##
-labkey.experiment.createRun <- function(config, dataInputs = NULL, dataOutputs = NULL, dataRows = NULL, materialInputs = NULL, materialOutputs = NULL, plateMetadata = NULL)
+labkey.experiment.createRun <- function(config, dataInputs = NULL, dataOutputs = NULL, dataRows = NULL, materialInputs = NULL, materialOutputs = NULL)
 {
     ## check required parameters
     if (missing(config))
@@ -125,11 +125,6 @@ labkey.experiment.createRun <- function(config, dataInputs = NULL, dataOutputs =
     	}
 
         run$dataRows <- rowsVector
-    }
-
-    if (!is.null(plateMetadata))
-    {
-        run$plateMetadata = plateMetadata;
     }
     return (run)
 }

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 3.2.2\cr
-Date: \tab 2024-06-06\cr
+Version: \tab 3.2.3\cr
+Date: \tab 2024-06-25\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }

--- a/Rlabkey/man/labkey.experiment.createRun.Rd
+++ b/Rlabkey/man/labkey.experiment.createRun.Rd
@@ -7,7 +7,7 @@ Create an experiment run object.
 \usage{
 labkey.experiment.createRun(config,
     dataInputs = NULL, dataOutputs = NULL, dataRows = NULL,
-    materialInputs = NULL, materialOutputs = NULL, plateMetadata = NULL)
+    materialInputs = NULL, materialOutputs = NULL)
 }
 \arguments{
   \item{config}{a list of base experiment object properties}
@@ -16,7 +16,6 @@ labkey.experiment.createRun(config,
   \item{dataRows}{(optional) a data frame containing data rows to be uploaded to the assay backed run}
   \item{materialInputs}{(optional) a list of experiment material objects to be used as material inputs to the run}
   \item{materialOutputs}{(optional) a list of experiment material objects to be used as material outputs to the run}
-  \item{plateMetadata}{(optional) if the assay supports plate templates, the plate metadata object to upload}
 }
 \details{
 Create an experiment run object which can be used in the saveBatch function.
@@ -47,36 +46,6 @@ run <- labkey.experiment.createRun(
         list(name="new run"), materialInputs = m1, materialOutputs = m2)
 labkey.experiment.saveBatch(baseUrl="http://labkey/", folderPath="home",
         protocolName=labkey.experiment.SAMPLE_DERIVATION_PROTOCOL, runList=run)
-
-## import an assay run which includes plate metadata
-
-df <- data.frame(participantId=c(1:3), visitId = c(10,20,30), welllocation = c("A1", "D11", "F12"))
-
-runConfig <- fromJSON(txt='{"assayId": 310,
-    "name" : "api imported run with plate metadata",
-    "properties" : {
-        "PlateTemplate" : "urn:lsid:labkey.com:PlateTemplate.Folder-6:d8bbec7d-34cd-1038-bd67-b3bd"
-    }
-}')
-
-plateMetadata <- fromJSON(txt='{
-      "control" : {
-        "positive" : {"dilution":  0.005},
-        "negative" : {"dilution":  1.0}
-      },
-      "sample" : {
-        "SA01" : {"dilution": 1.0, "ID" : 111, "Barcode" : "BC_111", "Concentration" : 0.0125},
-        "SA02" : {"dilution": 2.0, "ID" : 222, "Barcode" : "BC_222"},
-        "SA03" : {"dilution": 3.0, "ID" : 333, "Barcode" : "BC_333"},
-        "SA04" : {"dilution": 4.0, "ID" : 444, "Barcode" : "BC_444"}
-      }
-    }')
-
-run <- labkey.experiment.createRun(runConfig, dataRows = df, plateMetadata = plateMetadata)
-labkey.experiment.saveBatch(
-    baseUrl="http://labkey/", folderPath="home",
-    assayConfig=list(assayId = 310), runList=run
-)
 
 }
 }

--- a/Rlabkey/man/labkey.experiment.saveBatch.Rd
+++ b/Rlabkey/man/labkey.experiment.saveBatch.Rd
@@ -65,36 +65,6 @@ run <- labkey.experiment.createRun(
 labkey.experiment.saveBatch(baseUrl="http://labkey/", folderPath="home",
         protocolName=labkey.experiment.SAMPLE_DERIVATION_PROTOCOL, runList=run)
 
-## import an assay run which includes plate metadata
-
-df <- data.frame(participantId=c(1:3), visitId = c(10,20,30), welllocation = c("A1", "D11", "F12"))
-
-runConfig <- fromJSON(txt='{"assayId": 310,
-    "name" : "api imported run with plate metadata",
-    "properties" : {
-        "PlateTemplate" : "urn:lsid:labkey.com:PlateTemplate.Folder-6:d8bbec7d-34cd-1038-bd67-b3bd"
-    }
-}')
-
-plateMetadata <- fromJSON(txt='{
-      "control" : {
-        "positive" : {"dilution":  0.005},
-        "negative" : {"dilution":  1.0}
-      },
-      "sample" : {
-        "SA01" : {"dilution": 1.0, "ID" : 111, "Barcode" : "BC_111", "Concentration" : 0.0125},
-        "SA02" : {"dilution": 2.0, "ID" : 222, "Barcode" : "BC_222"},
-        "SA03" : {"dilution": 3.0, "ID" : 333, "Barcode" : "BC_333"},
-        "SA04" : {"dilution": 4.0, "ID" : 444, "Barcode" : "BC_444"}
-      }
-    }')
-
-run <- labkey.experiment.createRun(runConfig, dataRows = df, plateMetadata = plateMetadata)
-labkey.experiment.saveBatch(
-    baseUrl="http://labkey/", folderPath="home",
-    assayConfig=list(assayId = 310), runList=run
-)
-
 }
 }
 \keyword{IO}


### PR DESCRIPTION
#### Rationale
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50617)

This removes API support for importing assay data with JSON based plate metadata.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5626