### PR TITLE
Issue 51160: update jsonEncodeRowsAndParams() to better handle decimal values for toJSON()

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 3.3.0
-Date: 2024-08-08
+Version: 3.4.0
+Date: 2024-10-22
 Title: Data Exchange Between R and 'LabKey' Server
 Authors@R: c(person(given = "Peter",
                     family = "Hussey",

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 3.4.0
+  o Issue 51160: update jsonEncodeRowsAndParams() to better handle decimal values for toJSON()
+
 Changes in 3.3.0
   o Add labkey.experiment.lineage API to support getting parent/child relationships for exp objects by LSID
 

--- a/Rlabkey/R/makeDF.R
+++ b/Rlabkey/R/makeDF.R
@@ -237,7 +237,7 @@ convertFactorsToStrings <- function(df)
 jsonEncodeRowsAndParams <- function(rows, params, na=NULL)
 {
     nrows <- nrow(rows)
-    p1 <- toJSON(params, auto_unbox=TRUE)
+    p1 <- toJSON(params, auto_unbox=TRUE, digits = NA) # digits = NA to avoid trimming values (Issue 51160)
     cnames <- colnames(rows)
     p3 <- NULL
     for(j in 1:nrows)
@@ -247,7 +247,7 @@ jsonEncodeRowsAndParams <- function(rows, params, na=NULL)
         if (!is.null(na)) {
             cvalues[is.na(cvalues)] = na
         }
-        p2 <- toJSON(cvalues, auto_unbox=TRUE)
+        p2 <- toJSON(cvalues, auto_unbox=TRUE, digits = NA) # digits = NA to avoid trimming values (Issue 51160)
         p3 <- c(p3, p2)
     }
     p3 <- paste(p3, collapse=",")

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 3.3.0\cr
-Date: \tab 2024-08-08\cr
+Version: \tab 3.4.0\cr
+Date: \tab 2024-10-22\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51160

#### Changes
- update jsonEncodeRowsAndParams() to set "digits = NA" in toJSON() call
