### PR TITLE
Issue 51606: labkey.webdav.downloadFolder to match file path prefix to the href values returned in listDir, which are URL encoded paths

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 3.4.0
-Date: 2024-10-22
+Version: 3.4.1
+Date: 2024-11-08
 Title: Data Exchange Between R and 'LabKey' Server
 Authors@R: c(person(given = "Peter",
                     family = "Hussey",

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 3.4.1
+  o Issue 51606: labkey.webdav.downloadFolder to match file path prefix to the href values returned in listDir, which are URL encoded paths
+
 Changes in 3.4.0
   o Issue 51160: update jsonEncodeRowsAndParams() to better handle decimal values for toJSON()
 

--- a/Rlabkey/R/labkey.webdav.R
+++ b/Rlabkey/R/labkey.webdav.R
@@ -279,19 +279,19 @@ logMessage <- function(msg) {
 
 labkey.webdav.doDownloadFolder <- function(localDir, baseUrl=NULL, folderPath, remoteFilePath, depth, overwriteFiles=TRUE, mergeFolders=TRUE, fileSet="@files")
 {
-    # Note: this should use unencoded values to match the ID in JSON
     baseUrl <- normalizeSlash(baseUrl, leading = F, trailing = F)
-    folderPath <- normalizeSlash(folderPath, leading = F)
+    folderPath <- encodeFolderPath(folderPath);
     fileSet <- normalizeSlash(fileSet, leading = F, trailing = F)
-    remoteFilePath <- normalizeSlash(remoteFilePath, leading = F)
+    remoteFilePath <- normalizeSlash(encodeRemotePath(remoteFilePath), leading = F)
     localDir <- normalizeFolder(localDir)
-    
-    prefix <- paste0("/_webdav/", folderPath, fileSet, '/')  
-    
+
+    # Issue 51606: match file path prefix to the href values returned in listDir, which are URL encoded paths
+    prefix <- paste0("/_webdav", folderPath, encodeRemotePath(fileSet), '/')
+
     files <- labkey.webdav.listDir(baseUrl=baseUrl, folderPath=folderPath, fileSet=fileSet, remoteFilePath=remoteFilePath)
     for (file in files[["files"]]) {
-      relativeToRemoteRoot <- sub(prefix, "", file[["id"]])
-      relativeToDownloadStart <- sub(paste0(prefix, remoteFilePath), "", file[["id"]])
+      relativeToRemoteRoot <- sub(prefix, "", file[["href"]])
+      relativeToDownloadStart <- sub(paste0(prefix, remoteFilePath), "", file[["href"]])
 
       localPath <- file.path(localDir, relativeToDownloadStart)
       if (file[["isdirectory"]]) {

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 3.4.0\cr
-Date: \tab 2024-10-22\cr
+Version: \tab 3.4.1\cr
+Date: \tab 2024-11-08\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51606

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5961

#### Changes
- encode folderPath and remoteFilePath in labkey.webdav.doDownloadFolder 
- use the "href" instead of "id" for comparing paths for results of labkey.webdav.listDir 
