### PR TITLE
Add notes for 3.4.1 about required LK server version

### DIFF
--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,5 +1,6 @@
 Changes in 3.4.1
   o Issue 51606: labkey.webdav.downloadFolder to match file path prefix to the href values returned in listDir, which are URL encoded paths
+  o Note: requires LabKey Server v24.12 or later
 
 Changes in 3.4.0
   o Issue 51160: update jsonEncodeRowsAndParams() to better handle decimal values for toJSON()


### PR DESCRIPTION
#### Rationale
The fix for issue 51606 in the Rlabkey package is compatible with URL encoding changes in LabKey Server 24.12 and beyond. This PR updates the release notes in the package to indicate that.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-r/pull/110

#### Changes
- update release notes re: required LK version
