### PR TITLE
Add option to show progress bar for webdav downloads

### DIFF
--- a/Rlabkey/R/labkey.webdav.R
+++ b/Rlabkey/R/labkey.webdav.R
@@ -14,9 +14,9 @@
 #  limitations under the License.
 ##
 
-labkey.webdav.get <- function(baseUrl=NULL, folderPath, remoteFilePath, localFilePath, overwrite=TRUE, fileSet="@files")
+labkey.webdav.get <- function(baseUrl=NULL, folderPath, remoteFilePath, localFilePath, overwrite=TRUE, fileSet="@files", showProgressBar=FALSE)
 {
-    baseUrl=labkey.getBaseUrl(baseUrl);
+    baseUrl <- labkey.getBaseUrl(baseUrl);
 
     ## check required parameters
     if (missing(baseUrl) || is.null(baseUrl) || missing(folderPath) || missing(remoteFilePath) || missing(localFilePath)){
@@ -33,7 +33,7 @@ labkey.webdav.get <- function(baseUrl=NULL, folderPath, remoteFilePath, localFil
 
     url <- paste(baseUrl, "_webdav", folderPath, fileSet, "/", remoteFilePath, sep="");
 
-    ret <- labkey.webdav.getByUrl(url, localFilePath, overwrite)
+    ret <- labkey.webdav.getByUrl(url, localFilePath, overwrite, showProgressBar = showProgressBar)
     if (!is.null(ret) && !is.na(ret) && ret == FALSE) {
       return(FALSE)
     }
@@ -41,7 +41,7 @@ labkey.webdav.get <- function(baseUrl=NULL, folderPath, remoteFilePath, localFil
     return(file.exists(localFilePath))
 }
 
-labkey.webdav.getByUrl <- function(url, localFilePath, overwrite=TRUE)
+labkey.webdav.getByUrl <- function(url, localFilePath, overwrite=TRUE, showProgressBar=FALSE)
 {
     # dont bother querying if this file already exists, since we wont overwrite it
     if (!overwrite & file.exists(localFilePath)) {
@@ -59,11 +59,12 @@ labkey.webdav.getByUrl <- function(url, localFilePath, overwrite=TRUE)
 
     options <- labkey.getRequestOptions(method="GET")
 
+    progress <- ifelse(showProgressBar, yes = httr::progress(), no = NULL)
     if (!is.null(.lkdefaults[["debug"]]) && .lkdefaults[["debug"]] == TRUE){
         print(paste0("URL: ", url))
-        response <- GET(url=url, write_disk(localFilePath, overwrite=overwrite), config=options, verbose(data_in=TRUE, info=TRUE, ssl=TRUE))
+        response <- GET(url=url, write_disk(localFilePath, overwrite=overwrite), config=options, verbose(data_in=TRUE, info=TRUE, ssl=TRUE), progress)
     } else {
-        response <- GET(url=url, write_disk(localFilePath, overwrite=overwrite), config=options)
+        response <- GET(url=url, write_disk(localFilePath, overwrite=overwrite), config=options, progress)
     }
 
     processResponse(response)
@@ -120,7 +121,7 @@ labkey.webdav.mkDir <- function(baseUrl=NULL, folderPath, remoteFilePath, fileSe
 
 labkey.webdav.validateAndBuildRemoteUrl <- function(baseUrl=NULL, folderPath, remoteFilePath, fileSet="@files")
 {
-    baseUrl=labkey.getBaseUrl(baseUrl);
+    baseUrl <- labkey.getBaseUrl(baseUrl);
 
     ## check required parameters
     if (missing(baseUrl) || is.null(baseUrl) || missing(folderPath) || missing(fileSet) || missing(remoteFilePath)){
@@ -143,7 +144,7 @@ encodeRemotePath <- function(path, splitSlash = TRUE) {
 
 labkey.webdav.pathExists <- function(baseUrl=NULL, folderPath, remoteFilePath, fileSet="@files")
 {
-    baseUrl=labkey.getBaseUrl(baseUrl);
+    baseUrl <- labkey.getBaseUrl(baseUrl);
 
     if (missing(baseUrl) || is.null(baseUrl) || missing(folderPath) || missing(remoteFilePath)) {
         stop (paste("A value must be specified for each of baseUrl, folderPath, fileSet, and remoteFilePath"));
@@ -162,7 +163,7 @@ labkey.webdav.isDirectory <- function(baseUrl=NULL, folderPath, remoteFilePath, 
 
 labkey.webdav.listDir <- function(baseUrl=NULL, folderPath, remoteFilePath, fileSet="@files", haltOnError = TRUE)
 {
-    baseUrl=labkey.getBaseUrl(baseUrl);
+    baseUrl <- labkey.getBaseUrl(baseUrl);
 
     url <- labkey.webdav.validateAndBuildRemoteUrl(baseUrl=baseUrl, folderPath=folderPath, fileSet=fileSet, remoteFilePath=remoteFilePath)
     url <- paste0(url, "?method=JSON")
@@ -191,7 +192,7 @@ labkey.webdav.listDir <- function(baseUrl=NULL, folderPath, remoteFilePath, file
 
 labkey.webdav.delete <- function(baseUrl=NULL, folderPath, remoteFilePath, fileSet="@files")
 {
-    baseUrl=labkey.getBaseUrl(baseUrl);
+    baseUrl <- labkey.getBaseUrl(baseUrl);
 
     url <- labkey.webdav.validateAndBuildRemoteUrl(baseUrl=baseUrl, folderPath=folderPath, fileSet=fileSet, remoteFilePath=remoteFilePath)
     url <- paste0(url, "?method=DELETE")
@@ -206,7 +207,7 @@ labkey.webdav.delete <- function(baseUrl=NULL, folderPath, remoteFilePath, fileS
 
 labkey.webdav.mkDirs <- function(baseUrl=NULL, folderPath, remoteFilePath, fileSet="@files")
 {
-    baseUrl=labkey.getBaseUrl(baseUrl);
+    baseUrl <- labkey.getBaseUrl(baseUrl);
 
     if (missing(baseUrl) || is.null(baseUrl) || missing(folderPath) || missing(remoteFilePath)){
         stop (paste("A value must be specified for each of baseUrl, folderPath, fileSet, and remoteFilePath"))
@@ -226,7 +227,7 @@ labkey.webdav.mkDirs <- function(baseUrl=NULL, folderPath, remoteFilePath, fileS
     return(TRUE)
 }
 
-labkey.webdav.downloadFolder <- function(localBaseDir, baseUrl=NULL, folderPath, remoteFilePath, overwriteFiles=TRUE, mergeFolders=TRUE, fileSet="@files") {
+labkey.webdav.downloadFolder <- function(localBaseDir, baseUrl=NULL, folderPath, remoteFilePath, overwriteFiles=TRUE, mergeFolders=TRUE, fileSet="@files", showProgressBar=FALSE) {
   if (missing(localBaseDir) || missing(baseUrl) || is.null(baseUrl) || missing(folderPath) || missing(remoteFilePath)){
     stop (paste("A value must be specified for each of localBaseDir, baseUrl, folderPath, fileSet, and remoteFilePath"))
   }
@@ -257,7 +258,7 @@ labkey.webdav.downloadFolder <- function(localBaseDir, baseUrl=NULL, folderPath,
     return(F)
   }
   
-  labkey.webdav.doDownloadFolder(localDir = localBaseDir, baseUrl = baseUrl, folderPath = folderPath, remoteFilePath = remoteFilePath, overwriteFiles = overwriteFiles, mergeFolders = mergeFolders, fileSet = fileSet)
+  labkey.webdav.doDownloadFolder(localDir = localBaseDir, baseUrl = baseUrl, folderPath = folderPath, remoteFilePath = remoteFilePath, overwriteFiles = overwriteFiles, mergeFolders = mergeFolders, fileSet = fileSet, showProgressBar = showProgressBar)
 }
 
 normalizeFolder <- function(localDir){
@@ -277,7 +278,7 @@ logMessage <- function(msg) {
   }
 }
 
-labkey.webdav.doDownloadFolder <- function(localDir, baseUrl=NULL, folderPath, remoteFilePath, depth, overwriteFiles=TRUE, mergeFolders=TRUE, fileSet="@files")
+labkey.webdav.doDownloadFolder <- function(localDir, baseUrl=NULL, folderPath, remoteFilePath, overwriteFiles=TRUE, mergeFolders=TRUE, fileSet="@files", showProgressBar=FALSE)
 {
     baseUrl <- normalizeSlash(baseUrl, leading = F, trailing = F)
     folderPath <- encodeFolderPath(folderPath);
@@ -312,14 +313,14 @@ labkey.webdav.doDownloadFolder <- function(localDir, baseUrl=NULL, folderPath, r
           next
         }
         
-        labkey.webdav.doDownloadFolder(localDir=localPath, baseUrl=baseUrl, folderPath=folderPath, fileSet=fileSet, remoteFilePath=relativeToRemoteRoot, overwriteFiles=overwriteFiles, mergeFolders=mergeFolders)
+        labkey.webdav.doDownloadFolder(localDir=localPath, baseUrl=baseUrl, folderPath=folderPath, fileSet=fileSet, remoteFilePath=relativeToRemoteRoot, overwriteFiles=overwriteFiles, mergeFolders=mergeFolders, showProgressBar=showProgressBar)
       } else {
           url <- paste0(baseUrl, trimLeadingPath(file[["href"]]))
 
           logMessage(paste0("Downloading file: ", relativeToRemoteRoot))
           logMessage(paste0("to: ", localPath))
 
-          labkey.webdav.getByUrl(url, localPath, overwriteFiles)
+          labkey.webdav.getByUrl(url, localPath, overwriteFiles, showProgressBar=showProgressBar)
       }
     }
 
@@ -341,7 +342,7 @@ prepareDirectory <- function(localPath, overwriteFiles, mergeFolders) {
     
     if (!mergeFolders && overwriteFiles) {
       logMessage('deleting existing folder')
-      unlink(localPath, recursive = T)
+      unlink(localPath, recursive = TRUE)
     }
     else if (!mergeFolders && !overwriteFiles) {
       logMessage('skipping existing folder')
@@ -354,5 +355,5 @@ prepareDirectory <- function(localPath, overwriteFiles, mergeFolders) {
     dir.create(localPath, recursive=TRUE)
   }
   
-  return(T)
+  return(TRUE)
 }

--- a/Rlabkey/R/labkey.webdav.R
+++ b/Rlabkey/R/labkey.webdav.R
@@ -59,12 +59,16 @@ labkey.webdav.getByUrl <- function(url, localFilePath, overwrite=TRUE, showProgr
 
     options <- labkey.getRequestOptions(method="GET")
 
-    progress <- ifelse(showProgressBar, yes = httr::progress(), no = NULL)
+    progressBar <- NULL
+    if (showProgressBar) {
+      progressBar <- httr::progress()
+    }
+
     if (!is.null(.lkdefaults[["debug"]]) && .lkdefaults[["debug"]] == TRUE){
         print(paste0("URL: ", url))
-        response <- GET(url=url, write_disk(localFilePath, overwrite=overwrite), config=options, verbose(data_in=TRUE, info=TRUE, ssl=TRUE), progress)
+        response <- GET(url=url, write_disk(localFilePath, overwrite=overwrite), config=options, verbose(data_in=TRUE, info=TRUE, ssl=TRUE), progressBar)
     } else {
-        response <- GET(url=url, write_disk(localFilePath, overwrite=overwrite), config=options, progress)
+        response <- GET(url=url, write_disk(localFilePath, overwrite=overwrite), config=options, progressBar)
     }
 
     processResponse(response)

--- a/Rlabkey/man/labkey.webdav.downloadFolder.Rd
+++ b/Rlabkey/man/labkey.webdav.downloadFolder.Rd
@@ -12,7 +12,8 @@ labkey.webdav.downloadFolder(
     remoteFilePath,
     overwriteFiles=TRUE,
     mergeFolders=TRUE,
-    fileSet='@files'
+    fileSet='@files',
+    showProgressBar=FALSE
     )
 }
 \arguments{
@@ -23,6 +24,7 @@ labkey.webdav.downloadFolder(
   \item{overwriteFiles}{(optional) if true, any pre-existing file at this location will be overwritten.  Defaults to TRUE }
   \item{mergeFolders}{(optional) if false, any pre-existing local folders in the target location will be deleted if there is an incoming folder of the same name. If true, these existing folders will be left alone, and remote files downloaded into them.  Existing file conflicts will be handled based on the overwriteFiles parameter.  Defaults to TRUE }
   \item{fileSet}{(optional) the name of file server fileSet, which is typically "@files" (the default value for this argument).  In some cases this might be "@pipeline" or "@fileset". }
+  \item{showProgressBar}{(optional) if true, a progress bar will be shown for all file downloads }
 }
 \details{
 This will recursively download a folder from a LabKey Server using WebDAV.  This is essentially a wrapper that recursively calls

--- a/Rlabkey/man/labkey.webdav.get.Rd
+++ b/Rlabkey/man/labkey.webdav.get.Rd
@@ -11,7 +11,8 @@ labkey.webdav.get(
     remoteFilePath,
     localFilePath,
     overwrite=TRUE,
-    fileSet='@files'
+    fileSet='@files',
+    showProgressBar=FALSE
     )
 }
 \arguments{
@@ -21,6 +22,7 @@ labkey.webdav.get(
   \item{localFilePath}{the local filepath where this file will be saved }
   \item{overwrite}{(optional) if true, any pre-existing file at this location will be overwritten.  Defaults to TRUE }
   \item{fileSet}{(optional) the name of file server fileSet, which is typically "@files" (the default value for this argument). In some cases this might be "@pipeline" or "@fileset". }
+  \item{showProgressBar}{(optional))if true, a progress bar will be shown for all file downloads }
 }
 \details{
 Download a single file from a LabKey Server to the local machine using WebDAV.

--- a/docs/build_windows.md
+++ b/docs/build_windows.md
@@ -11,7 +11,7 @@
         * Click next. There is then an editable preview of the new system path. Leave as is.
         * If reinstalling Rtools, make sure there is only one copy of the new entries in the path
 
-* Install [MiKTeX](http://www.miktex.org/download) for Latex support
+* Install [MiKTeX](https://miktex.org/download) for Latex support
     * After installation, open the MiKTeX package manager and install these additional packages:
         * fancyvrb
         * inconsolata


### PR DESCRIPTION
This PR adds an optional argument to turn on a progress bar during webdav downloads. It's a native option in httr::GET(), so very simple to support. It's a nice feature to have when downloading a large file. 

I believe I updated the docs correctly; however, I dont usually do this by hand. Is that really how you manage these? Hopefully the tests will catch issues there?

I also made a handful of minor changes since I was looking at the code, including '=' to '<-', and the weird R-ism "T" -> "TRUE"