### PR TITLE
Document importing run domain properties

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Rlabkey
-Version: 3.4.4
+Version: 3.4.3
 Date: 2025-05-09
 Title: Data Exchange Between R and 'LabKey' Server
 Authors@R: c(person(given = "Peter",

--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 3.4.3
-Date: 2025-03-21
+Version: 3.4.4
+Date: 2025-05-09
 Title: Data Exchange Between R and 'LabKey' Server
 Authors@R: c(person(given = "Peter",
                     family = "Hussey",

--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
 Version: 3.4.3
-Date: 2025-05-09
+Date: 2025-03-21
 Title: Data Exchange Between R and 'LabKey' Server
 Authors@R: c(person(given = "Peter",
                     family = "Hussey",

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 3.4.4
+  o Update documentation for experiment.createRun to include an example of inserting run level properties
+
 Changes in 3.4.3
   o Bugfix to labkey.selectRows when group_concat based field has a NULL value. Related to github issue #112
 

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,8 +1,6 @@
-Changes in 3.4.4
-  o Update documentation for experiment.createRun to include an example of inserting run level properties
-
 Changes in 3.4.3
   o Bugfix to labkey.selectRows when group_concat based field has a NULL value. Related to github issue #112
+  o Update documentation for experiment.createRun to include an example of inserting run level properties
 
 Changes in 3.4.2
   o Add showProgressBar parameter to labkey.webdav.downloadFolder and labkey.webdav.get

--- a/Rlabkey/man/labkey.experiment.createRun.Rd
+++ b/Rlabkey/man/labkey.experiment.createRun.Rd
@@ -10,7 +10,7 @@ labkey.experiment.createRun(config,
     materialInputs = NULL, materialOutputs = NULL)
 }
 \arguments{
-  \item{config}{a list of base experiment object properties}
+  \item{config}{A list of base experiment object properties. Note that run domain properties must be added to a properties sub-object.}
   \item{dataInputs}{(optional) a list of experiment data objects to be used as data inputs to the run}
   \item{dataOutputs}{(optional) a list of experiment data objects to be used as data outputs to the run}
   \item{dataRows}{(optional) a data frame containing data rows to be uploaded to the assay backed run}
@@ -42,8 +42,12 @@ m1 <- labkey.experiment.createMaterial(
         list(name = "87444063.2604.626"), sampleSetName = "Study Specimens")
 m2 <- labkey.experiment.createMaterial(
         list(name = "87444063.2604.625"), sampleSetName = "Study Specimens")
+
+## create the run configuration and include optional run level properties
+runConfig <- list(name="new run", properties <- list(textField="run prop 1", floatField=3.14))
+
 run <- labkey.experiment.createRun(
-        list(name="new run"), materialInputs = m1, materialOutputs = m2)
+        runConfig, materialInputs = m1, materialOutputs = m2)
 labkey.experiment.saveBatch(baseUrl="http://labkey/", folderPath="home",
         protocolName=labkey.experiment.SAMPLE_DERIVATION_PROTOCOL, runList=run)
 


### PR DESCRIPTION
#### Rationale
tracking issue : https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52529

Update the Rlabkey documentation for `experiment.createRun` to provide guidance on importing run properties.


