### PR TITLE
Issue 53043: labkey.webdav.downloadFolder to account for contextPath in file href paths

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
 Version: 3.4.3
-Date: 2025-03-21
+Date: 2025-05-12
 Title: Data Exchange Between R and 'LabKey' Server
 Authors@R: c(person(given = "Peter",
                     family = "Hussey",

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,5 +1,6 @@
 Changes in 3.4.3
   o Bugfix to labkey.selectRows when group_concat based field has a NULL value. Related to github issue #112
+  o Issue 53043: labkey.webdav.downloadFolder to account for contextPath in file href paths
 
 Changes in 3.4.2
   o Add showProgressBar parameter to labkey.webdav.downloadFolder and labkey.webdav.get

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -19,7 +19,7 @@ schema objects (\code{labkey.getSchema}).
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
 Version: \tab 3.4.2\cr
-Date: \tab 2025-03-12\cr
+Date: \tab 2025-05-12\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }


### PR DESCRIPTION
#### Rationale
The labkey.webdav.downloadFolder queries the server for the set of files/dir in the remote dir location and then iterates over them to download. It uses the href attribute of the files/dir to get the relative path. This issue came up when we started adding a contextPath = /labkey in TeamCity as the parsing of that href attr wasn't accounting for it starting with that contextPath.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-r/pull/110

#### Changes
- account for contextPath in file href paths
