### PR TITLE
Additional validation for assay run configurations

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Rlabkey
-Version: 3.4.3
+Version: 3.4.4
 Date: 2025-05-12
 Title: Data Exchange Between R and 'LabKey' Server
 Authors@R: c(person(given = "Peter",

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 3.4.4
+  o Issue 53481: additional validation for assay run configurations.
+
 Changes in 3.4.3
   o Bugfix to labkey.selectRows when group_concat based field has a NULL value. Related to github issue #112
   o Update documentation for experiment.createRun to include an example of inserting run level properties

--- a/Rlabkey/R/labkey.experiment.R
+++ b/Rlabkey/R/labkey.experiment.R
@@ -74,6 +74,10 @@ labkey.experiment.createRun <- function(config, dataInputs = NULL, dataOutputs =
 
     run <- config
 
+    ## validate run properties if provided
+    if (!is.null(run$properties) && !is.list(run$properties))
+        stop (paste("run properties must be a list of key value pairs."))
+
     if (!is.null(dataInputs))
     {
         if (!is.list(dataInputs))

--- a/Rlabkey/R/labkey.experiment.R
+++ b/Rlabkey/R/labkey.experiment.R
@@ -76,7 +76,7 @@ labkey.experiment.createRun <- function(config, dataInputs = NULL, dataOutputs =
 
     ## validate run properties if provided
     if (!is.null(run$properties) && !is.list(run$properties))
-        stop (paste("run properties must be a list of key value pairs."))
+        stop (paste("config properties must be a list of key value pairs."))
 
     if (!is.null(dataInputs))
     {


### PR DESCRIPTION
#### Rationale
[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53481)

This change validates the shape of the run properties that might be passed into the `experiment.createRun` function so we don't fail when we try to parse the JSON posted data on the server. The repro is to run this or similar code:

```
runConfig <- fromJSON(txt='{"name" : "api imported run",
    "properties" : ["lab" , "test lab", "location" , "Seattle"]
    }')

run <- labkey.experiment.createRun(runConfig, dataRows = df)
```

The other client APIs don't seem to have this problem due to the presence of more composed types versus allowing free form JSON text.

With this change, if the properties object is not valid, we will throw the following error (list is the R data type that serializes to a JSON object):

<img width="470" height="57" alt="image" src="https://github.com/user-attachments/assets/16eeeec4-5405-42c3-a2a6-8003dcff1fed" />
