### PR TITLE
Improve validate for zero-row dataframes

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Rlabkey
-Version: 3.4.4
+Version: 3.4.5
 Date: 2025-05-12
 Title: Data Exchange Between R and 'LabKey' Server
 Authors@R: c(person(given = "Peter",

--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Rlabkey
-Version: 3.4.5
+Version: 3.4.4
 Date: 2025-05-12
 Title: Data Exchange Between R and 'LabKey' Server
 Authors@R: c(person(given = "Peter",

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,8 +1,6 @@
-Changes in 3.4.5
-  o Improve validation when a zero-row dataframe is passed to insertRows/updateRows/deleteRows
-
 Changes in 3.4.4
   o Issue 53481: additional validation for assay run configurations.
+  o Improve validation when a zero-row dataframe is passed to insertRows/updateRows/deleteRows
 
 Changes in 3.4.3
   o Bugfix to labkey.selectRows when group_concat based field has a NULL value. Related to github issue #112

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,3 +1,6 @@
+Changes in 3.4.5
+  o Improve validation when a zero-row dataframe is passed to insertRows/updateRows/deleteRows
+
 Changes in 3.4.4
   o Issue 53481: additional validation for assay run configurations.
 

--- a/Rlabkey/R/labkey.deleteRows.R
+++ b/Rlabkey/R/labkey.deleteRows.R
@@ -26,6 +26,7 @@ labkey.deleteRows <- function(baseUrl=NULL, folderPath, schemaName, queryName, t
     if (missing(schemaName)) stop (paste("A value must be specified for schemaName."))
     if (missing(queryName)) stop (paste("A value must be specified for queryName."))
     if (missing(toDelete)) stop (paste("A value must be specified for toDelete."))
+    if (nrow(toDelete) == 0) stop (paste("toDelete must contain at least one row."))
     if (!missing(options) & !is.list(options))
         stop (paste("The options parameter must be a list data structure."))
 

--- a/Rlabkey/R/labkey.importRows.R
+++ b/Rlabkey/R/labkey.importRows.R
@@ -26,6 +26,7 @@ labkey.importRows <- function(baseUrl=NULL, folderPath, schemaName, queryName, t
     if (missing(schemaName)) stop (paste("A value must be specified for schemaName."))
     if (missing(queryName)) stop (paste("A value must be specified for queryName."))
     if (missing(toImport)) stop (paste("A value must be specified for toImport."))
+    if (nrow(toImport) == 0) stop (paste("toImport must contain at least one row."))
 
     ## normalize the folder path
     folderPath <- encodeFolderPath(folderPath)

--- a/Rlabkey/R/labkey.insertRows.R
+++ b/Rlabkey/R/labkey.insertRows.R
@@ -23,6 +23,7 @@ labkey.insertRows <- function(baseUrl=NULL, folderPath, schemaName, queryName, t
     if (missing(schemaName)) stop (paste("A value must be specified for schemaName."))
     if (missing(queryName)) stop (paste("A value must be specified for queryName."))
     if (missing(toInsert)) stop (paste("A value must be specified for toInsert."))
+    if (nrow(toInsert) == 0) stop (paste("toInsert must contain at least one row."))
     if (!missing(options) & !is.list(options))
         stop (paste("The options parameter must be a list data structure."))
 

--- a/Rlabkey/R/labkey.updateRows.R
+++ b/Rlabkey/R/labkey.updateRows.R
@@ -26,6 +26,7 @@ labkey.updateRows <- function(baseUrl=NULL, folderPath, schemaName, queryName, t
     if (missing(schemaName)) stop (paste("A value must be specified for schemaName."))
     if (missing(queryName)) stop (paste("A value must be specified for queryName."))
     if (missing(toUpdate)) stop (paste("A value must be specified for toUpdate."))
+    if (nrow(toUpdate) == 0) stop (paste("toUpdate must contain at least one row."))
     if (!missing(options) & !is.list(options))
         stop (paste("The options parameter must be a list data structure."))
 

--- a/Rlabkey/R/makeDF.R
+++ b/Rlabkey/R/makeDF.R
@@ -240,7 +240,7 @@ jsonEncodeRowsAndParams <- function(rows, params, na=NULL)
     p1 <- toJSON(params, auto_unbox=TRUE, digits = NA) # digits = NA to avoid trimming values (Issue 51160)
     cnames <- colnames(rows)
     p3 <- NULL
-    for(j in 1:nrows)
+    for(j in seq_len(nrows))
     {
         cvalues <- as.list(rows[j,])
         names(cvalues) <- cnames


### PR DESCRIPTION
As-is, users can supply an empty data.frame to insert/update/deleteRows. jsonEncodeRowsAndParams() will convert that zero-row DF into a one-row DF with NAs for all the fields. The subsequent API call will usually fail.

This PR will:

1) make insert/update/deleteRows fail immediately if a zero-row DF is passed. This seems like a reasonable validation.
2) It fixes the code in jsonEncodeRowsAndParams() so it wont make the single-row 'NA' df. The reason that happened is the for loop would try to iterate from "1:nrow(df)", which is "1:0". Using seq_len() is generally better practice since it handles zero rows better.
