### PR TITLE
Rlabkey 3.4.4: update version and release date

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
 Version: 3.4.4
-Date: 2025-05-12
+Date: 2025-09-16
 Title: Data Exchange Between R and 'LabKey' Server
 Authors@R: c(person(given = "Peter",
                     family = "Hussey",

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 3.4.2\cr
-Date: \tab 2025-05-12\cr
+Version: \tab 3.4.4\cr
+Date: \tab 2025-09-16\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }


### PR DESCRIPTION
#### Rationale
We are ready to publish Rlabkey v3.4.4. This PR updates the version number and release date in a couple places.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-r/pull/118 
- https://github.com/LabKey/labkey-api-r/pull/119 
