### PR TITLE
Bump Rlabkey version to 3.5.0 and update release notes

### DIFF
--- a/Rlabkey/DESCRIPTION
+++ b/Rlabkey/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rlabkey
-Version: 3.4.6
-Date: 2026-02-17
+Version: 3.5.0
+Date: 2026-06-29
 Title: Data Exchange Between R and 'LabKey' Server
 Authors@R: c(person(given = "Peter",
                     family = "Hussey",

--- a/Rlabkey/NEWS
+++ b/Rlabkey/NEWS
@@ -1,6 +1,7 @@
-Changes in 3.X
+Changes in 3.5.0
   o Pass auditUserComment to labkey.storage.delete for attaching a reason to the audit log record
   o labkey.storage.create and labkey.storage.update now accept an optional auditUserComment entry inside the props list (recorded as the "Reason" on the resulting audit event)
+  o makeDF support for bigint
 
 Changes in 3.4.6
   o Incorporate new filter types for Array (Multi-value text choice) fields

--- a/Rlabkey/man/Rlabkey-package.Rd
+++ b/Rlabkey/man/Rlabkey-package.Rd
@@ -18,8 +18,8 @@ schema objects (\code{labkey.getSchema}).
 \tabular{ll}{
 Package: \tab Rlabkey\cr
 Type: \tab Package\cr
-Version: \tab 3.4.6\cr
-Date: \tab 2026-02-17\cr
+Version: \tab 3.5.0\cr
+Date: \tab 2026-06-29\cr
 License: \tab Apache License 2.0\cr
 LazyLoad: \tab yes\cr
 }

--- a/test/install-rlabkey-dependencies.R
+++ b/test/install-rlabkey-dependencies.R
@@ -15,4 +15,4 @@
 ##
 
 source("install-util.R")
-install.dependencies("Rlabkey", c("rjson", "bitops", "Rcpp", "httr"))
+install.dependencies("Rlabkey", c("rjson", "bitops", "Rcpp", "httr", "bit64"))


### PR DESCRIPTION
#### Rationale
Bumping version for the changes in the following PRs:
https://github.com/LabKey/labkey-api-r/pull/128
https://github.com/LabKey/labkey-api-r/pull/126
